### PR TITLE
Doc formatting and typo fixes. Remove const name case warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bnf"
-version = "0.2.2"
-authors = ["Shea Newton"]
+version = "0.2.3"
+authors = ["@shnewto", "@CrockAgile", "@androm3da"]
 
 description = "A library for parsing Backus–Naur form context-free grammars"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ inspired by the JavaScript libraries [prettybnf](https://github.com/dhconnelly/p
 The following grammar from the
 [Wikipedia page on Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Example)
 exemplifies a compatible grammar. (*Note: parser allows for an optional ';'
-to indicate the end of a producion)
+to indicate the end of a production)
 
 ```text
-<postal-address> ::= <name-part> <street-address> <zip-part>
+ <postal-address> ::= <name-part> <street-address> <zip-part>
 
-        <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+      <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
                     | <personal-part> <name-part>
 
-    <personal-part> ::= <initial> "." | <first-name>
+  <personal-part> ::= <initial> "." | <first-name>
 
-    <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
+ <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
 
-        <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>
+       <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>
 
 <opt-suffix-part> ::= "Sr." | "Jr." | <roman-numeral> | ""
     <opt-apt-num> ::= <apt-num> | ""

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -68,10 +68,10 @@ impl Grammar {
     }
 
     fn traverse(&self, ident: &String, rng: &mut StdRng) -> Result<String, Error> {
-        const stack_red_zone: usize = 32 * 1024; // 32KB
+        const STACK_RED_ZONE: usize = 32 * 1024; // 32KB
         // heavy recursion happening, we've hit out tolerable threshold
         if let Some(remaining) = stacker::remaining_stack() {
-            if remaining < stack_red_zone {
+            if remaining < STACK_RED_ZONE {
                 return Err(Error::RecursionLimit(format!(
                             "Limit for recursion reached processing <{}>!",
                             ident)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,16 @@
 //! to indicate the end of a producion)
 //!
 //! ```text
-//! <postal-address> ::= <name-part> <street-address> <zip-part>
+//!  <postal-address> ::= <name-part> <street-address> <zip-part>
 //!
-//!         <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+//!       <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
 //!                     | <personal-part> <name-part>
 //!
-//!     <personal-part> ::= <initial> "." | <first-name>
+//!   <personal-part> ::= <initial> "." | <first-name>
 //!
-//!     <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
+//!  <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
 //!
-//!         <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>
+//!        <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>
 //!
 //! <opt-suffix-part> ::= "Sr." | "Jr." | <roman-numeral> | ""
 //!     <opt-apt-num> ::= <apt-num> | ""


### PR DESCRIPTION
- Doc formatting and typo fixes. Remove const name case warning.
- Bump version, add the rest of the authors.