### PR TITLE
Added len() function for Production to return number of rhs Expressions

### DIFF
--- a/src/production.rs
+++ b/src/production.rs
@@ -66,6 +66,11 @@ impl Production {
             iterator: self.rhs.iter_mut(),
         }
     }
+
+    /// Get number of right hand side `Expression`s
+    pub fn len(&self) -> usize {
+        self.rhs.len()
+    }
 }
 
 impl fmt::Display for Production {


### PR DESCRIPTION
I need to easily access the number of rhs `Expression`s, but the rhs `Vec` is private.

This is a quick addition to return the length of the rhs `Vec`.