### PR TITLE
Upgraded bnf to use nom 5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ version = "0.1.2"
 version = "0.3.17"
 
 [dependencies.nom]
-version = "^3.2"
-features = ["verbose-errors"]
+version = "^5.0.1"
 
 [dev-dependencies.quickcheck]
 version = "0.4.1"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,5 +1,4 @@
 use error::Error;
-use nom::IResult;
 use parsers;
 use std::fmt;
 use std::slice;
@@ -26,9 +25,8 @@ impl Expression {
     // Get `Expression` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
         match parsers::expression_complete(s.as_bytes()) {
-            IResult::Done(_, o) => Ok(o),
-            IResult::Incomplete(n) => Err(Error::from(n)),
-            IResult::Error(e) => Err(Error::from(e)),
+            Result::Ok((_,o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e))
         }
     }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,6 +1,5 @@
 use error::Error;
 use expression::Expression;
-use nom::IResult;
 use parsers;
 use production::Production;
 use rand::{thread_rng, Rng, SeedableRng, StdRng};
@@ -32,9 +31,8 @@ impl Grammar {
     // Get `Grammar` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
         match parsers::grammar_complete(s.as_bytes()) {
-            IResult::Done(_, o) => Ok(o),
-            IResult::Incomplete(n) => Err(Error::from(n)),
-            IResult::Error(e) => Err(Error::from(e)),
+            Result::Ok((_,o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e))
         }
     }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -23,8 +23,8 @@ named!(pub terminal< &[u8], Term >,
 
 named!(pub nonterminal< &[u8], Term >,
     do_parse!(
-        nt: delimited!(char!('<'), take_until!(">"), ws!(char!('>'))) >>
-        ws!(not!(tag!("::="))) >>
+        nt: complete!(delimited!(char!('<'), take_until!(">"), ws!(char!('>')))) >>
+        ws!(not!(complete!(tag!("::=")))) >>
         (Term::Nonterminal(String::from_utf8_lossy(nt).into_owned()))
     )
 );
@@ -49,7 +49,8 @@ named!(pub expression_next,
 
 named!(pub expression< &[u8], Expression >,
     do_parse!(
-        terms: many1!(term) >>
+        peek!(term) >>
+        terms: many1!(complete!(term)) >>
         ws!(
             alt!(
                 recognize!(peek!(complete!(eof!()))) |
@@ -73,7 +74,7 @@ named!(pub expression_complete< &[u8], Expression >,
 named!(pub production< &[u8], Production >,
     do_parse!(
         lhs: ws!(prod_lhs) >>
-        rhs: many1!(expression) >>
+        rhs: many1!(complete!(expression)) >>
         ws!(
             alt!(
                 recognize!(peek!(complete!(eof!()))) |
@@ -95,7 +96,8 @@ named!(pub production_complete< &[u8], Production >,
 
 named!(pub grammar< &[u8], Grammar >,
     do_parse!(
-        prods: many1!(production) >>
+        peek!(production) >>
+        prods: many1!(complete!(production)) >>
         (Grammar::from_parts(prods))
     )
 );

--- a/src/production.rs
+++ b/src/production.rs
@@ -1,6 +1,5 @@
 use error::Error;
 use expression::Expression;
-use nom::IResult;
 use parsers;
 use std::fmt;
 use std::slice;
@@ -31,9 +30,8 @@ impl Production {
     // Get `Production` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
         match parsers::production_complete(s.as_bytes()) {
-            IResult::Done(_, o) => Ok(o),
-            IResult::Incomplete(n) => Err(Error::from(n)),
-            IResult::Error(e) => Err(Error::from(e)),
+            Result::Ok((_,o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e))
         }
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,5 +1,4 @@
 use error::Error;
-use nom::IResult;
 use parsers;
 use std::fmt;
 use std::str::FromStr;
@@ -15,9 +14,8 @@ impl Term {
     // Get `Term` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
         match parsers::term_complete(s.as_bytes()) {
-            IResult::Done(_, o) => Ok(o),
-            IResult::Incomplete(n) => Err(Error::from(n)),
-            IResult::Error(e) => Err(Error::from(e)),
+            Result::Ok((_,o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e))
         }
     }
 }


### PR DESCRIPTION
There should be no functional changes from this migration, however some of the parsers and error handlers needed to be updated to handle changes in nom API/behavior.

I made this change because I was looking adding a new parser for EBNF support and noticed that the nom version was 2 years out of date. If there was a reason nom 3.2 was being used, this change isn't required.