### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/iterate.rs
+++ b/tests/iterate.rs
@@ -28,7 +28,7 @@ fn iterate_grammar() {
         .collect();
 
     // check nonterminals are in left and right hand terms collection
-    for term in ["dna", "base"].into_iter() {
+    for term in ["dna", "base"].iter() {
         let term_string = String::from(*term);
         let expected_nonterminal = Term::Nonterminal(term_string);
 
@@ -52,7 +52,7 @@ fn iterate_grammar() {
         .collect();
 
     // check terminals are only on right hand side
-    for term in ["A", "C", "G", "T"].into_iter() {
+    for term in ["A", "C", "G", "T"].iter() {
         let term_string = String::from(*term);
         let expected_terminal = Term::Terminal(term_string);
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.