### PR TITLE
Phase out old nom macros

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,13 +32,13 @@ impl error::Error for Error {
 
 impl<'a> From<VerboseError<(&'a str, VerboseErrorKind)>> for Error {
     fn from(err: VerboseError<(&str, VerboseErrorKind)>) -> Self {
-        Error::ParseError(format!("{:?}", err))
+        Error::ParseError(format!("Parsing error: {:?}", err))
     }
 }
 
 impl<'a> From<Err<VerboseError<&str>>> for Error {
     fn from(err: Err<VerboseError<&str>>) -> Self {
-        Error::ParseError(format!("{:?}", err))
+        Error::ParseError(format!("Parsing error: {:?}", err))
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -24,7 +24,7 @@ impl Expression {
 
     // Get `Expression` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::expression_complete(s.as_bytes()) {
+        match parsers::expression_complete(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
@@ -280,10 +280,10 @@ mod tests {
         assert!(result.is_err(), "{:?} should be err", result);
         match result {
             Err(e) => match e {
-                Error::ParseIncomplete(_) => (),
-                e => panic!("should should be Error::ParseIncomplete: {:?}", e),
+                Error::ParseError(_) => (),
+                e => panic!("should should be Error::ParseError: {:?}", e),
             },
-            Ok(s) => panic!("should should be Error::ParseIncomplete: {}", s),
+            Ok(s) => panic!("should should be Error::ParseError: {}", s),
         }
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use term::Term;
 
 /// An Expression is comprised of any number of Terms
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Expression {
     terms: Vec<Term>,
 }
@@ -20,14 +20,6 @@ impl Expression {
     /// Construct an `Expression` from `Term`s
     pub fn from_parts(v: Vec<Term>) -> Expression {
         Expression { terms: v }
-    }
-
-    // Get `Expression` by parsing a string
-    pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::expression_complete(s) {
-            Result::Ok((_, o)) => Ok(o),
-            Result::Err(e) => Err(Error::from(e)),
-        }
     }
 
     /// Add `Term` to `Expression`
@@ -98,7 +90,10 @@ impl FromStr for Expression {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str(s)
+        match parsers::expression_complete(s) {
+            Result::Ok((_, o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e)),
+        }
     }
 }
 
@@ -137,7 +132,7 @@ mod tests {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             let mut terms = Vec::<Term>::arbitrary(g);
             // expressions must always have atleast one term
-            if terms.len() < 1 {
+            if terms.is_empty() {
                 terms.push(Term::arbitrary(g));
             }
             Expression { terms }
@@ -145,8 +140,8 @@ mod tests {
     }
 
     fn prop_to_string_and_back(expr: Expression) -> TestResult {
-        let to_string = expr.to_string();
-        let from_str = Expression::from_str(&to_string);
+        let to_string: String = expr.to_string();
+        let from_str: Result<Expression, _> = to_string.parse();
         match from_str {
             Ok(from_expr) => TestResult::from_bool(from_expr == expr),
             _ => TestResult::error(format!("{} to string and back should be safe", expr)),

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -30,7 +30,7 @@ impl Grammar {
 
     // Get `Grammar` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::grammar_complete(s.as_bytes()) {
+        match parsers::grammar_complete(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
@@ -96,7 +96,7 @@ impl Grammar {
         let expressions = production.rhs_iter().collect::<Vec<&Expression>>();
 
         match rng.choose(&expressions) {
-            Some(e) => expression = e.clone(),
+            Some(e) => expression = e,
             None => {
                 return Err(Error::GenerateError(String::from(
                     "Couldn't select random Expression!",
@@ -112,7 +112,7 @@ impl Grammar {
             }
         }
 
-        return Ok(result);
+        Ok(result)
     }
 
     /// Generate a random sentence from self and seed for random.
@@ -405,15 +405,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_incomplete() {
+    fn parse_error_on_incomplete() {
         let result = Grammar::from_str("");
         assert!(result.is_err(), "{:?} should be err", result);
         match result {
             Err(e) => match e {
-                Error::ParseIncomplete(_) => (),
-                e => panic!("should should be Error::ParseIncomplete: {:?}", e),
+                Error::ParseError(_) => (),
+                e => panic!("should should be Error::ParseError: {:?}", e),
             },
-            Ok(s) => panic!("should should be Error::ParseIncomplete: {}", s),
+            Ok(s) => panic!("should should be Error::ParseError: {}", s),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,6 @@
 //! ```
 //!
 
-#[macro_use]
 extern crate nom;
 extern crate rand;
 extern crate stacker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@
 //!         <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
 //!             <opt-apt-num> ::= <apt-num> | \"\"";
 //!
-//!     let grammar = Grammar::from_str(input);
+//!     let grammar: Result<Grammar, _> = input.parse();
 //!     match grammar {
 //!         Ok(g) => println!("{:#?}", g),
 //!         Err(e) => println!("Failed to make grammar from String: {}", e),
@@ -153,7 +153,7 @@
 //!     let input =
 //!         "<dna> ::= <base> | <base> <dna>
 //!         <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
-//!     let grammar = Grammar::from_str(input).unwrap();
+//!     let grammar: Grammar = input.parse().unwrap();
 //!     let sentence = grammar.generate();
 //!     match sentence {
 //!         Ok(s) => println!("random sentence: {}", s),

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -3,112 +3,155 @@ use grammar::Grammar;
 use production::Production;
 use term::Term;
 
-named!(pub prod_lhs< &[u8], Term >,
-    do_parse!(
-            nt: delimited!(char!('<'), take_until!(">"), ws!(char!('>'))) >>
-            _ret: ws!(tag!("::=")) >>
-            (Term::Nonterminal(String::from_utf8_lossy(nt).into_owned()))
-    )
-);
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until},
+    character::complete,
+    combinator::{all_consuming, complete, peek, recognize},
+    error::VerboseError,
+    multi::many1,
+    sequence::{delimited, preceded, terminated},
+    IResult,
+};
 
-named!(pub terminal< &[u8], Term >,
-    do_parse!(
-        t: alt!(
-            delimited!(char!('"'), take_until!("\""), ws!(char!('"'))) |
-            delimited!(char!('\''), take_until!("'"), ws!(char!('\'')))
-            ) >>
-        (Term::Terminal(String::from_utf8_lossy(t).into_owned()))
-    )
-);
+fn prod_lhs<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+    let (input, _) = delimited(
+        complete::char('<'),
+        take_until(">"),
+        preceded(
+            complete::multispace0,
+            terminated(complete::char('>'), complete::multispace1),
+        ),
+    )(input)?;
 
-named!(pub nonterminal< &[u8], Term >,
-    do_parse!(
-        nt: complete!(delimited!(char!('<'), take_until!(">"), ws!(char!('>')))) >>
-        ws!(not!(complete!(tag!("::=")))) >>
-        (Term::Nonterminal(String::from_utf8_lossy(nt).into_owned()))
-    )
-);
+    let (input, nt) = preceded(
+        complete::multispace0,
+        terminated(tag("::="), complete::multispace1),
+    )(input)?;
 
-named!(pub term< &[u8], Term >, alt!(terminal | nonterminal));
+    Ok((input, Term::Nonterminal(String::from(nt))))
+}
 
-named!(pub term_complete< &[u8], Term >,
-    do_parse!(
-        t: term >>
-        eof!() >>
-        (t)
-    )
-);
+fn terminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+    let (input, t) = alt((
+        delimited(
+            complete::char('"'),
+            take_until("\""),
+            preceded(
+                complete::multispace0,
+                terminated(complete::char('"'), complete::multispace1),
+            ),
+        ),
+        preceded(
+            complete::multispace0,
+            terminated(tag("::="), complete::multispace1),
+        ),
+    ))(input)?;
 
-named!(pub expression_next,
-    do_parse!(
-        ws!(char!('|')) >>
-        ret: recognize!(peek!(complete!(expression))) >>
-        (ret)
-    )
-);
+    Ok((input, Term::Nonterminal(String::from(t))))
+}
 
-named!(pub expression< &[u8], Expression >,
-    do_parse!(
-        peek!(term) >>
-        terms: many1!(complete!(term)) >>
-        ws!(
-            alt!(
-                recognize!(peek!(complete!(eof!()))) |
-                recognize!(peek!(complete!(char!(';')))) |
-                expression_next |
-                recognize!(peek!(complete!(prod_lhs)))
-            )
-        ) >>
-        (Expression::from_parts(terms))
-    )
-);
+fn nonterminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+    let (input, nt) = complete(delimited(
+        complete::char('<'),
+        take_until(">"),
+        preceded(
+            complete::multispace0,
+            terminated(complete::char('>'), complete::multispace1),
+        ),
+    ))(input)?;
 
-named!(pub expression_complete< &[u8], Expression >,
-    do_parse!(
-        e: expression >>
-        eof!() >>
-        (e)
-    )
-);
+    let (input, _) = complete(preceded(
+        complete::multispace0,
+        terminated(tag("::="), complete::multispace1),
+    ))(input)?;
 
-named!(pub production< &[u8], Production >,
-    do_parse!(
-        lhs: ws!(prod_lhs) >>
-        rhs: many1!(complete!(expression)) >>
-        ws!(
-            alt!(
-                recognize!(peek!(complete!(eof!()))) |
-                tag!(";") |
-                recognize!(peek!(complete!(prod_lhs)))
-            )
-        ) >>
-        (Production::from_parts(lhs, rhs))
-    )
-);
+    Ok((input, Term::Nonterminal(String::from(nt))))
+}
 
-named!(pub production_complete< &[u8], Production >,
-    do_parse!(
-        p: production >>
-        eof!() >>
-        (p)
-    )
-);
+fn term<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+    let (input, t) = alt((terminal, nonterminal))(input)?;
 
-named!(pub grammar< &[u8], Grammar >,
-    do_parse!(
-        peek!(production) >>
-        prods: many1!(complete!(production)) >>
-        (Grammar::from_parts(prods))
-    )
-);
+    Ok((input, t))
+}
 
-named!(pub grammar_complete< &[u8], Grammar >,
-    do_parse!(
-        g: grammar >>
-        eof!() >>
-        (g)
-    )
-);
+fn term_complete<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+    let (input, t) = all_consuming(term)(input)?;
+
+    Ok((input, t))
+}
+
+fn expression_next<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+    let (input, _) = preceded(
+        complete::multispace0,
+        terminated(complete::char('|'), complete::multispace1),
+    )(input)?;
+
+    let (input, e) = recognize(peek(complete(expression)))(input)?;
+
+    Ok((input, e))
+}
+
+fn expression<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
+    let (input, _) = peek(term)(input)?;
+
+    let (input, terms) = many1(complete(term))(input)?;
+    let (input, _) = preceded(
+        complete::multispace0,
+        terminated(
+            alt((
+                recognize(peek(complete(complete::char(';')))),
+                expression_next,
+                recognize(peek(complete(prod_lhs))),
+            )),
+            complete::multispace1,
+        ),
+    )(input)?;
+
+    Ok((input, Expression::from_parts(terms)))
+}
+
+fn expression_complete<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
+    let (input, e) = all_consuming(expression)(input)?;
+
+    Ok((input, e))
+}
+
+fn production<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&'a str>> {
+    let (input, lhs) = preceded(
+        complete::multispace0,
+        terminated(prod_lhs, complete::multispace1),
+    )(input)?;
+    let (input, rhs) = many1(complete(expression))(input)?;
+    let (input, _) = preceded(
+        complete::multispace0,
+        terminated(
+            alt((tag(";"), recognize(peek(complete(prod_lhs))))),
+            complete::multispace1,
+        ),
+    )(input)?;
+
+    Ok((input, Production::from_parts(lhs, rhs)))
+}
+
+fn production_complete<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&'a str>> {
+    let (input, p) = all_consuming(production)(input)?;
+
+    Ok((input, p))
+}
+
+fn grammar<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
+    let (input, _) = peek(production)(input)?;
+    let (input, prods) = many1(complete(production))(input)?;
+
+    Ok((input, Grammar::from_parts(prods)))
+}
+
+fn grammar_complete<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
+    let (input, g) = all_consuming(grammar)(input)?;
+
+    Ok((input, g))
+}
 
 #[cfg(test)]
 mod tests {
@@ -127,7 +170,7 @@ mod tests {
         let terminal_tuple = construct_terminal_tuple();
         assert_eq!(
             terminal_tuple.0,
-            terminal(terminal_tuple.1.as_bytes()).unwrap().1
+            terminal(terminal_tuple.1.as_str()).unwrap().1
         );
     }
 
@@ -144,7 +187,7 @@ mod tests {
         let nonterminal_tuple = construct_nonterminal_tuple();
         assert_eq!(
             nonterminal_tuple.0,
-            nonterminal(nonterminal_tuple.1.as_bytes()).unwrap().1
+            nonterminal(nonterminal_tuple.1.as_str()).unwrap().1
         );
     }
 
@@ -162,7 +205,7 @@ mod tests {
         let expression_tuple = construct_expression_tuple();
         assert_eq!(
             expression_tuple.0,
-            expression(expression_tuple.1.as_bytes()).unwrap().1
+            expression(expression_tuple.1.as_str()).unwrap().1
         );
     }
 
@@ -186,7 +229,7 @@ mod tests {
     #[test]
     fn production_match() {
         let production_tuple = construct_production_tuple();
-        let parsed = production(production_tuple.1.as_bytes());
+        let parsed = production(production_tuple.1.as_str());
         assert_eq!(production_tuple.0, parsed.unwrap().1);
     }
 
@@ -206,7 +249,7 @@ mod tests {
         let grammar_tuple = construct_grammar_tuple();
         assert_eq!(
             grammar_tuple.0,
-            grammar(grammar_tuple.1.as_bytes()).unwrap().1
+            grammar(grammar_tuple.1.as_str()).unwrap().1
         );
     }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -4,17 +4,69 @@ use production::Production;
 use term::Term;
 
 use nom::{
+    self,
     branch::alt,
     bytes::complete::{tag, take_until},
     character::complete,
     combinator::{all_consuming, complete, peek, recognize},
-    error::VerboseError,
+    error::{ErrorKind, ParseError, VerboseError, VerboseErrorKind},
     multi::many1,
     sequence::{delimited, preceded, terminated},
     IResult,
 };
 
-fn prod_lhs<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+fn eoi<I: Clone + std::string::ToString, O, E: ParseError<I>, F>(
+    f: F,
+) -> impl Fn(I) -> IResult<I, O, E>
+where
+    F: Fn(I) -> IResult<I, O, E>,
+{
+    move |input: I| {
+        if input.to_string().len() == 0 {
+            Ok((input, input))
+        } else {
+            Err(nom::Err::Error(VerboseError {
+                errors: vec![("EOI not found", VerboseErrorKind::Nom(ErrorKind::Eof))],
+            }))
+        }
+    }
+}
+// //
+// macro_rules! eof (
+//   ($i:expr,) => (
+//     {
+//       if ($i).input_len() == 0 {
+//         Ok(($i, $i))
+//       } else {
+//         Err(Err::Error(error_position!($i, ErrorKind::Eof)))
+//       }
+//     }
+//   );
+// )
+//     // if input.len() == 0 {
+//     Ok((input, input))
+// } else {
+//     Err(nom::Err::Error(VerboseError {
+//         errors: vec![("EOI not found", VerboseErrorKind::Nom(ErrorKind::Eof))],
+//     }))
+// }
+
+// pub fn complete<I: Clone, O, E: ParseError<I>, F>(f: F) -> impl Fn(I) -> IResult<I, O, E>
+// where
+//   F: Fn(I) -> IResult<I, O, E>,
+// {
+//   move |input: I| {
+//     let i = input.clone();
+//     match f(input) {
+//       Err(Err::Incomplete(_)) => {
+//         Err(Err::Error(E::from_error_kind(i, ErrorKind::Complete)))
+//       },
+//       rest => rest
+//     }
+//   }
+// }
+
+pub fn prod_lhs<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
     let (input, _) = delimited(
         complete::char('<'),
         take_until(">"),
@@ -32,7 +84,7 @@ fn prod_lhs<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>>
     Ok((input, Term::Nonterminal(String::from(nt))))
 }
 
-fn terminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+pub fn terminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
     let (input, t) = alt((
         delimited(
             complete::char('"'),
@@ -51,7 +103,7 @@ fn terminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>>
     Ok((input, Term::Nonterminal(String::from(t))))
 }
 
-fn nonterminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+pub fn nonterminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
     let (input, nt) = complete(delimited(
         complete::char('<'),
         take_until(">"),
@@ -69,19 +121,19 @@ fn nonterminal<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a st
     Ok((input, Term::Nonterminal(String::from(nt))))
 }
 
-fn term<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+pub fn term<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
     let (input, t) = alt((terminal, nonterminal))(input)?;
 
     Ok((input, t))
 }
 
-fn term_complete<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
+pub fn term_complete<'a>(input: &'a str) -> IResult<&'a str, Term, VerboseError<&'a str>> {
     let (input, t) = all_consuming(term)(input)?;
 
     Ok((input, t))
 }
 
-fn expression_next<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+pub fn expression_next<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
     let (input, _) = preceded(
         complete::multispace0,
         terminated(complete::char('|'), complete::multispace1),
@@ -92,7 +144,7 @@ fn expression_next<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'
     Ok((input, e))
 }
 
-fn expression<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
+pub fn expression<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
     let (input, _) = peek(term)(input)?;
 
     let (input, terms) = many1(complete(term))(input)?;
@@ -100,6 +152,7 @@ fn expression<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&
         complete::multispace0,
         terminated(
             alt((
+                recognize(peek(complete(eoi()))),
                 recognize(peek(complete(complete::char(';')))),
                 expression_next,
                 recognize(peek(complete(prod_lhs))),
@@ -111,13 +164,15 @@ fn expression<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&
     Ok((input, Expression::from_parts(terms)))
 }
 
-fn expression_complete<'a>(input: &'a str) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
+pub fn expression_complete<'a>(
+    input: &'a str,
+) -> IResult<&'a str, Expression, VerboseError<&'a str>> {
     let (input, e) = all_consuming(expression)(input)?;
 
     Ok((input, e))
 }
 
-fn production<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&'a str>> {
+pub fn production<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&'a str>> {
     let (input, lhs) = preceded(
         complete::multispace0,
         terminated(prod_lhs, complete::multispace1),
@@ -126,7 +181,11 @@ fn production<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&
     let (input, _) = preceded(
         complete::multispace0,
         terminated(
-            alt((tag(";"), recognize(peek(complete(prod_lhs))))),
+            alt((
+                recognize(peek(complete(tag("")))),
+                tag(";"),
+                recognize(peek(complete(prod_lhs))),
+            )),
             complete::multispace1,
         ),
     )(input)?;
@@ -134,20 +193,22 @@ fn production<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&
     Ok((input, Production::from_parts(lhs, rhs)))
 }
 
-fn production_complete<'a>(input: &'a str) -> IResult<&'a str, Production, VerboseError<&'a str>> {
+pub fn production_complete<'a>(
+    input: &'a str,
+) -> IResult<&'a str, Production, VerboseError<&'a str>> {
     let (input, p) = all_consuming(production)(input)?;
 
     Ok((input, p))
 }
 
-fn grammar<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
+pub fn grammar<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
     let (input, _) = peek(production)(input)?;
     let (input, prods) = many1(complete(production))(input)?;
 
     Ok((input, Grammar::from_parts(prods)))
 }
 
-fn grammar_complete<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
+pub fn grammar_complete<'a>(input: &'a str) -> IResult<&'a str, Grammar, VerboseError<&'a str>> {
     let (input, g) = all_consuming(grammar)(input)?;
 
     Ok((input, g))

--- a/src/production.rs
+++ b/src/production.rs
@@ -31,7 +31,7 @@ impl Production {
 
     // Get `Production` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::production_complete(s.as_bytes()) {
+        match parsers::production_complete(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
@@ -288,10 +288,10 @@ mod tests {
         assert!(result.is_err(), "{:?} should be err", result);
         match result {
             Err(e) => match e {
-                Error::ParseIncomplete(_) => (),
-                e => panic!("should should be Error::ParseIncomplete: {:?}", e),
+                Error::ParseError(_) => (),
+                e => panic!("should should be Error::ParseError: {:?}", e),
             },
-            Ok(s) => panic!("should should be Error::ParseIncomplete: {}", s),
+            Ok(s) => panic!("should should be Error::ParseError: {}", s),
         }
     }
 

--- a/src/production.rs
+++ b/src/production.rs
@@ -29,14 +29,6 @@ impl Production {
         Production { lhs: t, rhs: e }
     }
 
-    // Get `Production` by parsing a string
-    pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::production_complete(s) {
-            Result::Ok((_, o)) => Ok(o),
-            Result::Err(e) => Err(Error::from(e)),
-        }
-    }
-
     /// Add `Expression` to the `Production`'s right hand side
     pub fn add_to_rhs(&mut self, expr: Expression) {
         self.rhs.push(expr)
@@ -100,9 +92,11 @@ impl fmt::Display for Production {
 
 impl FromStr for Production {
     type Err = Error;
-
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str(s)
+        match parsers::production_complete(s) {
+            Result::Ok((_, o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e)),
+        }
     }
 }
 
@@ -148,7 +142,7 @@ mod tests {
             let lhs = Term::Nonterminal(lhs_str);
 
             let mut rhs = Vec::<Expression>::arbitrary(g);
-            if rhs.len() < 1 {
+            if rhs.is_empty() {
                 rhs.push(Expression::arbitrary(g));
             }
             Production { lhs, rhs }

--- a/src/term.rs
+++ b/src/term.rs
@@ -12,20 +12,13 @@ pub enum Term {
     Nonterminal(String),
 }
 
-impl Term {
-    // Get `Term` by parsing a string
-    pub fn from_str(s: &str) -> Result<Self, Error> {
+impl FromStr for Term {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match parsers::term_complete(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
-    }
-}
-
-impl FromStr for Term {
-    type Err = Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str(s)
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -15,7 +15,7 @@ pub enum Term {
 impl Term {
     // Get `Term` by parsing a string
     pub fn from_str(s: &str) -> Result<Self, Error> {
-        match parsers::term_complete(s.as_bytes()) {
+        match parsers::term_complete(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
@@ -108,10 +108,10 @@ mod tests {
         assert!(result.is_err(), "{:?} should be err", result);
         match result {
             Err(e) => match e {
-                Error::ParseIncomplete(_) => (),
-                e => panic!("should should be Error::ParseIncomplete: {:?}", e),
+                Error::ParseError(_) => (),
+                e => panic!("should should be Error::ParseError: {:?}", e),
             },
-            Ok(s) => panic!("should should be Error::ParseIncomplete: {}", s),
+            Ok(s) => panic!("should should be Error::ParseError: {}", s),
         }
     }
 

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -27,7 +27,7 @@ fn validate_terminated_display() {
                           <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
                           <opt-apt-num> ::= <apt-num> | \"\"\n";
 
-    let grammar = Grammar::from_str(input).unwrap();
+    let grammar: Grammar = input.parse().unwrap();
 
     assert_eq!(grammar.to_string(), display_output);
 }
@@ -57,7 +57,7 @@ fn validate_nonterminated_display() {
                           <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
                           <opt-apt-num> ::= <apt-num> | \"\"\n";
 
-    let grammar = Grammar::from_str(input).unwrap();
+    let grammar: Grammar = input.parse().unwrap();
 
     assert_eq!(grammar.to_string(), display_output);
 }
@@ -91,6 +91,6 @@ fn grammar_with_quotes() {
                           ::= \"Hello, world!\"\n\
                           ";
 
-    let grammar = Grammar::from_str(input).expect("Grammar with quotes should parse");
+    let grammar: Grammar = input.parse().expect("Grammar with quotes should parse");
     assert_eq!(grammar.to_string(), display_output);
 }

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -53,7 +53,7 @@ mod custom_trait {
     #[test]
     fn expression_from_str() {
         let input = "\"😵\" \"😋\" \"😉\"";
-        let expression = Expression::from_str(input);
+        let expression: Result<Expression, _> = input.parse();
         assert!(expression.is_ok())
     }
 
@@ -61,28 +61,28 @@ mod custom_trait {
     fn grammar_from_str() {
         let input = "<🙃> ::= \"😵\" \"😋\" | \"😉\"
         <🤘> ::= \"👏 \" \"👊\" | \"👌\"";
-        let grammar = Grammar::from_str(input);
+        let grammar: Result<Grammar, _> = input.parse();
         assert!(grammar.is_ok())
     }
 
     #[test]
     fn production_from_str() {
         let input = "<🤘> ::= \"👏 \" \"👊\" | \"👌\"";
-        let production = Production::from_str(input);
+        let production: Result<Production, _> = input.parse();
         assert!(production.is_ok())
     }
 
     #[test]
     fn terminal_from_str() {
         let input = "\"👏 \"";
-        let terminal = Term::from_str(input);
+        let terminal: Result<Term, _> = input.parse();
         assert!(terminal.is_ok())
     }
 
     #[test]
     fn nonterminal_from_str() {
         let input = "<🤘>";
-        let nonterminal = Term::from_str(input);
+        let nonterminal: Result<Term, _> = input.parse();
         assert!(nonterminal.is_ok())
     }
 }

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -55,7 +55,7 @@ const BNF_FOR_BNF: &str = "
 impl Arbitrary for Meta {
     fn arbitrary<G: Gen>(g: &mut G) -> Meta {
         // Generate Grammar object from grammar for BNF grammars
-        let grammar = Grammar::from_str(BNF_FOR_BNF);
+        let grammar: Result<Grammar, _> = BNF_FOR_BNF.parse();
         assert!(grammar.is_ok(), "{:?} should be Ok", grammar);
 
         // generate a random valid grammar from the above
@@ -83,7 +83,7 @@ impl Arbitrary for Meta {
 
 fn prop_grammar_from_str(meta: Meta) -> TestResult {
     // parse a randomly generated grammar to a Grammar object
-    let meta_grammar = Grammar::from_str(&meta.bnf);
+    let meta_grammar: Result<Grammar, _> = meta.bnf.parse();
     TestResult::from_bool(meta_grammar.is_ok())
 }
 

--- a/tests/iterate.rs
+++ b/tests/iterate.rs
@@ -8,7 +8,7 @@ fn iterate_grammar() {
         <dna> ::= <base> | <base> <dna>
         <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
 
-    let dna_grammar = Grammar::from_str(dna_productions).unwrap();
+    let dna_grammar: Grammar = dna_productions.parse().unwrap();
 
     let left_hand_terms: Vec<&Term> = dna_grammar
         .productions_iter()
@@ -70,7 +70,7 @@ fn mutably_iterate_grammar() {
         <dna> ::= <dna> | <base> <dna>;
         <base> ::= \"A\" | \"C\" | \"G\" | \"T\";";
 
-    let mut dna_grammar = Grammar::from_str(dna_productions).unwrap();
+    let mut dna_grammar: Grammar = dna_productions.parse().unwrap();
 
     // scope mutable borrow
     {

--- a/tests/iterate.rs
+++ b/tests/iterate.rs
@@ -99,7 +99,7 @@ fn mutably_iterate_grammar() {
             _ => false,
         })
         .all(|term| match *term {
-            Term::Terminal(ref s) => *s == String::from("Z"),
+            Term::Terminal(ref s) => *s == "Z",
             _ => false,
         });
 


### PR DESCRIPTION
Went through all of the old nom style macros implemented and took a nom 5 approach, using only functions. Some fall out from that included simplifying our error reporting, I'm not even sure why we were differentiating parse from incomplete errors in the first place...

Another part of these changes is tackling a bunch of stuff clippy warned about. The most significant change there was removing the weirdness where I was implementing FromStr for each object as well as a `from_str` in each object's impl. Now instead of seeing `let x = Object::from_str("...")`, we're using `let x: Result<Object,_> = "...".parse()` 