### PR TITLE
(Incomplete) Implementation of ISO 14977 compliant EBNF parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ license = "MIT"
 [features]
 unstable = []
 
+[dependencies]
+pest = "2.1.3"
+pest_derive = "2.1.0"
+
 [dependencies.stacker]
 version = "0.1.2"
 

--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -82,11 +82,6 @@ vertical_tabulation_character = {
 // ISO 6429 character Form Feed
 form_feed = { "\\f" }
 
-// The second part of the syntax defines the
-// removal of unnecessary non-printing characters
-// from a syntax.
-// See 6.4 Gap-separators.
-
 terminal_character = {
     ASCII_ALPHA
     | ASCII_DIGIT
@@ -110,70 +105,21 @@ terminal_character = {
     | other_character
 }
 
-// see 6.3
-
-terminal_character_without_quote_symbols = {
-    ASCII_ALPHA
-    | ASCII_DIGIT
-    | concatenate_symbol
-    | defining_symbol
-    | definition_separator_symbol
-    | end_comment_symbol
-    | end_group_symbol
-    | end_option_symbol
-    | end_repeat_symbol
-    | except_symbol
-    | repetition_symbol
-    | special_sequence_symbol
-    | start_comment_symbol
-    | start_group_symbol
-    | start_option_symbol
-    | start_repeat_symbol
-    | terminator_symbol
-    | other_character
-}
-
-gap_free_symbol = {
-    terminal_character_without_quote_symbols
-    | terminal_string
-}
-
 // see 4.16
 terminal_string = @{
     (first_quote_symbol ~ (first_terminal_character)+ ~ first_quote_symbol)
     | (second_quote_symbol ~ (second_terminal_character)+ ~ second_quote_symbol)
 }
 
-// see 4.17
-
+// See 4.17
 first_terminal_character = { 
     !(first_quote_symbol) ~ terminal_character
  }
 
-// see 4.18
-
+// See 4.18
 second_terminal_character = { 
     !(second_quote_symbol) ~ terminal_character
- }
-
-// See 6.4
-gap_separator = {
-    space_character
-    | horizontal_tabulation_character
-    | NEWLINE
-    | vertical_tabulation_character
-    | form_feed
 }
-
-// See 6.5
-syntax_without_gap_separators = {
-    ((gap_separator)* ~ gap_free_symbol)+ ~ (gap_separator)*
-}
-
-// The third part of the syntax defines the
-// removal of bracketed-textual-comments from
-// gap-free-symbols that form a syntax.
-// See 6.6
 
 // See 4.9
 integer = @{ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
@@ -218,7 +164,7 @@ special_sequence_character = {
 
 // The final part of the syntax defines the
 // abstract syntax of Extended BNF, i.e. the
-// structure in terms of the commentless symbols.
+// structure in terms of the comment-less symbols.
 
 // See 4.3
 syntax_rule = {
@@ -241,7 +187,7 @@ syntactic_term = {
 }
 
 // See 4.7
-// syntactic_exception must be checked ourselves.
+// NOTE: syntactic_exception must be checked ourselves.
 syntactic_exception = {
     (integer ~ repetition_symbol)? ~ syntactic_primary
 }
@@ -259,7 +205,6 @@ syntactic_primary = {
     | meta_identifier
     | terminal_string
     | special_sequence
-//  | empty_sequence
 }
 
 // See 4.11
@@ -277,13 +222,11 @@ grouped_sequence = {
     start_group_symbol ~ definition_list ~ end_group_symbol
 }
 
-// See 4.21
-// empty_sequence = {};
-
 // See 4.2
 syntax = {
     SOI ~ syntax_rule+ ~ EOI
 }
 
+// See chapter 6.4 on Gap Separators
 WHITESPACE = _{ " " | NEWLINE | "\t" | "\u{000B}" }
 COMMENT = _{ "(*" ~ (!"*)" ~ ANY)* ~ "*)" }

--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -1,0 +1,231 @@
+// The syntax of Extended BNF can be defined using
+// itself. There are four parts in this example,
+// the first part names the characters, the second
+// part defines the removal of unnecessary nonprinting characters, the third part defines the
+// removal of textual comments, and the final part
+// defines the structure of Extended BNF itself.
+// Each syntax rule in this example starts with a
+// comment that identifies the corresponding clause
+// in the standard.
+// The meaning of special-sequences is not defined
+// in the standard. In this example (see the
+// reference to 7.6) they represent control
+// functions defined by ISO/IEC 6429:1992.
+// Another special-sequence defines a
+// syntactic-exception (see the reference to 4.7).
+
+// The first part of the lexical syntax defines the
+// characters in the 7-bit character set (ISO/IEC
+// 646:1991) that represent each terminal-character
+// and gap-separator in Extended BNF.
+
+//  see 7.2
+letter = {
+"a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" |
+"u" | "v" | "w" | "x" | "y" | "z" | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M" | "N" |
+"O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+}
+
+// see 7.2
+decimal_digit = {
+"0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+}
+
+// The representation of the following
+// terminal-characters is defined in clauses 7.3,
+// 7.4 and tables 1, 2.
+concatenate_symbol = { "," }
+defining_symbol = { "=" }
+definition_separator_symbol = {
+"|" |
+"//" |
+"!"
+}
+end_comment_symbol = { "*)" }
+end_group_symbol = { ")" }
+end_option_symbol = {
+"]"
+| "/)"
+}
+end_repeat_symbol = {
+"}"
+| ":)"
+}
+except_symbol = { "-" }
+first_quote_symbol = { "\"" }
+repetition_symbol = { "*" }
+second_quote_symbol = { "\"" }
+special_sequence_symbol = { "?" }
+start_comment_symbol = { "(*" }
+start_group_symbol = { "(" }
+start_option_symbol = {
+"["
+| "(/"
+}
+start_repeat_symbol = {
+"{"
+| "(:"
+}
+terminator_symbol = {
+" }"
+| "."
+}
+
+// see 7.5
+other_character = {
+" " | ":" | "+" | "_" | "%" | "@" | "&" | "#" | "$" | "<" | ">" | "\\" | "ˆ" | "‘" | "˜"
+}
+
+// see 7.6
+space_character = { " " }
+
+// ISO 6429 character Carriage Return
+carriage_return = { "\r" }
+
+// ISO 6429 character Horizontal Tabulation
+horizontal_tabulation_character = { "\n" }
+
+new_line = { carriage_return* ~ horizontal_tabulation_character ~ carriage_return* }
+
+// ISO 6429 character Vertical Tabulation
+vertical_tabulation_character = {
+"\v" |
+"\u{000B}"
+}
+
+// ISO 6429 character Form Feed
+form_feed = { "\f" }
+
+// The second part of the syntax defines the
+// removal of unnecessary non-printing characters
+// from a syntax.
+// See 6.4 Gap-separators.
+
+terminal_character = {
+letter
+| decimal_digit
+| concatenate_symbol
+| defining_symbol
+| definition_separator_symbol
+| end_comment_symbol
+| end_group_symbol
+| end_option_symbol
+| end_repeat_symbol
+| except_symbol
+| first_quote_symbol
+| repetition_symbol
+| second_quote_symbol
+| special_sequence_symbol
+| start_comment_symbol
+| start_group_symbol
+| start_option_symbol
+| start_repeat_symbol
+| terminator_symbol
+| other_character
+}
+
+// see 6.3
+
+terminal_character_without_quote_symbols = {
+letter
+| decimal_digit
+| concatenate_symbol
+| defining_symbol
+| definition_separator_symbol
+| end_comment_symbol
+| end_group_symbol
+| end_option_symbol
+| end_repeat_symbol
+| except_symbol
+| repetition_symbol
+| special_sequence_symbol
+| start_comment_symbol
+| start_group_symbol
+| start_option_symbol
+| start_repeat_symbol
+| terminator_symbol
+| other_character
+}
+
+gap_free_symbol = {
+terminal_character_without_quote_symbols
+| terminal_string
+}
+
+// see 4.16
+terminal_string = {
+first_quote_symbol ~ (first_terminal_character)+ ~ first_quote_symbol
+| second_quote_symbol ~ (second terminal character)+ ~ second quote symbol
+}
+
+// see 4.17
+
+terminal_character_without_first_quote_symbol = {
+letter
+| decimal_digit
+| concatenate_symbol
+| defining_symbol
+| definition_separator_symbol
+| end_comment_symbol
+| end_group_symbol
+| end_option_symbol
+| end_repeat_symbol
+| except_symbol
+| repetition_symbol
+| second_quote_symbol
+| special_sequence_symbol
+| start_comment_symbol
+| start_group_symbol
+| start_option_symbol
+| start_repeat_symbol
+| terminator_symbol
+| other_character
+}
+
+first_terminal_character = { terminal_character_without_first_quote_symbol }
+
+// see 4.18
+
+terminal_character_without_second_quote_symbol = {
+letter
+| decimal_digit
+| concatenate_symbol
+| defining_symbol
+| definition_separator_symbol
+| end_comment_symbol
+| end_group_symbol
+| end_option_symbol
+| end_repeat_symbol
+| except_symbol
+| first_quote_symbol
+| repetition_symbol
+| special_sequence_symbol
+| start_comment_symbol
+| start_group_symbol
+| start_option_symbol
+| start_repeat_symbol
+| terminator_symbol
+| other_character
+}
+
+second_terminal_character = { terminal_character_without_second_quote_symbol }
+
+// See 6.4
+gap_separator = {
+space_character
+| horizontal_tabulation_character
+| new_line
+| vertical_tabulation_character
+| form_feed
+}
+
+// See 6.5
+syntax = {
+(gap_separator)* ~ gap_free_symbol ~ (gap_separator)* ~ gap_free_symbol ~ (gap_separator)*
+}
+
+// The third part of the syntax defines the
+// removal of bracketed-textual-comments from
+// gap-free-symbols that form a syntax.
+// See 6.6
+commentless_symbol = terminal character - (letter

--- a/src/iso_14977/mod.rs
+++ b/src/iso_14977/mod.rs
@@ -1,0 +1,18 @@
+#[derive(Parser)]
+#[grammar = "ebnf.pest"]
+pub struct CSVParser;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pest::Parser;
+
+    #[test]
+    fn test_config() {
+        let successful_parse = CSVParser::parse(Rule::field, "-273.15");
+        println!("{:?}", successful_parse);
+        let unsuccessful_parse = CSVParser::parse(Rule::field, "this is not a number");
+        println!("{:?}", unsuccessful_parse);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! The following grammar from the [Wikipedia page on Backus-Naur form]
 //! (https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Example)
-//! exemplifies a compatible grammar. (*Note: parser allows for an optional ';'
+//! exemplifies a compatible grammar. (*Note: iso_14977 allows for an optional ';'
 //! to indicate the end of a producion)
 //!
 //! ```text
@@ -164,11 +164,15 @@
 //!
 
 extern crate nom;
+extern crate pest;
 extern crate rand;
 extern crate stacker;
+#[macro_use]
+extern crate pest_derive;
 mod error;
 mod expression;
 mod grammar;
+pub mod iso_14977;
 mod parsers;
 mod production;
 mod term;


### PR DESCRIPTION
<!--
If you're not sure what to write, here's a bit of an outline to get you started. No requirement to conform though if you're comfortable providing some appropriate info. 

- Title / short summary of the changes in this PR
- Prior to this PR ____ / how things were and why things needed to change
- After this PR ____ / how things have changed
- Note design decisions / anything that may not be immediately evident when reading the diffs
-->

### Implementation of ISO 14977 compliant EBNF parser

Prior to this PR, this crate only supports BNF parser.
It also didn't use lingos that align with EBNF.
I needed something more "official" and also more powerful since EBNF contains more operators than just `defining-separator-symbol`.

Admittedly, I am quite sure that BNF can do everything that EBNF can do.
It just requires a bit manual work.

Another functionality that I wanted is the ability to validate a given string and not just generate them.
I will leave that to another PR.

## Note

1. Figure out why when parsing for `definition_list` in something like `(5 * {"abcde"} - "xyz") | "fghi";` we will get the following `single_definition` => `(5 * {"abcde"} - "xyz") ` (with the space included). This should have been detected by the implicit whitespaces...