### PR TITLE
chore: factor long bnf text fixtures into their own files

### DIFF
--- a/tests/display.rs
+++ b/tests/display.rs
@@ -4,20 +4,7 @@ use bnf::Grammar;
 
 #[test]
 fn validate_terminated_display() {
-    let input = "<postal-address> ::= <name-part> <street-address> <zip-part>;
-
-            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
-                            | <personal-part> <name-part>;
-
-        <personal-part> ::= <initial> \".\" | <first-name>;
-
-        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
-
-            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;
-
-        <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";
-            <opt-apt-num> ::= <apt-num> | \"\";";
-
+    let input = std::include_str!("./fixtures/postal_address.terminated.input.bnf");
     let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
                           <name-part> ::= <personal-part> <last-name> \
                           <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
@@ -34,20 +21,7 @@ fn validate_terminated_display() {
 
 #[test]
 fn validate_nonterminated_display() {
-    let input = "<postal-address> ::= <name-part> <street-address> <zip-part>
-
-            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
-                            | <personal-part> <name-part>
-
-        <personal-part> ::= <initial> \".\" | <first-name>
-
-        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
-
-            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>
-
-        <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
-            <opt-apt-num> ::= <apt-num> | \"\"";
-
+    let input = std::include_str!("./fixtures/postal_address.nonterminated.input.bnf");
     let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
                           <name-part> ::= <personal-part> <last-name> \
                           <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\

--- a/tests/fixtures/bnf.bnf
+++ b/tests/fixtures/bnf.bnf
@@ -33,4 +33,5 @@
 <character2>     ::= <character> | '"'
 <rule-name>      ::= <letter> | <rule-name> <rule-char>
 <rule-char>      ::= <letter> | <digit> | "-"
-<EOL>            ::= "\n"
+<EOL>            ::= "
+"

--- a/tests/fixtures/bnf.bnf
+++ b/tests/fixtures/bnf.bnf
@@ -1,0 +1,36 @@
+<syntax>         ::= <rule> | <rule> <syntax>
+<rule>           ::= <opt-whitespace> "<" <rule-name> ">"
+                     <opt-whitespace> "::=" <opt-whitespace>
+                     <expression> <line-end>
+<opt-whitespace> ::= "" | " " <opt-whitespace>
+<expression>     ::= <list> | <list> <opt-whitespace> "|"
+                     <opt-whitespace> <expression>
+<line-end>       ::= <opt-whitespace> <EOL>
+<list>           ::= <term> | <term> <opt-whitespace> <list>
+<term>           ::= <literal> | "<" <rule-name> ">"
+<literal>        ::= '"' <text1> '"' | "'" <text2> "'"
+<text1>          ::= "" | <character1> <text1>
+<text2>          ::= "" | <character2> <text2>
+<character>      ::= <letter> | <digit> | <symbol>
+<letter>         ::= "A" | "B" | "C" | "D" | "E" | "F"
+                    | "G" | "H" | "I" | "J" | "K" | "L"
+                    | "M" | "N" | "O" | "P" | "Q" | "R"
+                    | "S" | "T" | "U" | "V" | "W" | "X"
+                    | "Y" | "Z" | "a" | "b" | "c" | "d"
+                    | "e" | "f" | "g" | "h" | "i" | "j"
+                    | "k" | "l" | "m" | "n" | "o" | "p"
+                    | "q" | "r" | "s" | "t" | "u" | "v"
+                    | "w" | "x" | "y" | "z"
+<digit>          ::= "0" | "1" | "2" | "3" | "4" | "5"
+                    | "6" | "7" | "8" | "9"
+<symbol>         ::=  "|" | " " | "-" | "!" | "#" | "$"
+                    | "%" | "&" | "(" | ")" | "*" | "+"
+                    | "," | "-" | "." | "/" | ":" | ";"
+                    |">" | "=" | "<" | "?" | "@" | "["
+                    | "\\" | "]" | "^" | "_" | "`"
+                    | "{{" | "}}" | "~"
+<character1>     ::= <character> | "'"
+<character2>     ::= <character> | '"'
+<rule-name>      ::= <letter> | <rule-name> <rule-char>
+<rule-char>      ::= <letter> | <digit> | "-"
+<EOL>            ::= "\n"

--- a/tests/fixtures/postal_address.nonterminated.input.bnf
+++ b/tests/fixtures/postal_address.nonterminated.input.bnf
@@ -1,0 +1,13 @@
+ <postal-address> ::= <name-part> <street-address> <zip-part>;
+
+            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+                            | <personal-part> <name-part>;
+
+        <personal-part> ::= <initial> "." | <first-name>;
+
+        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
+
+            <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>;
+
+        <opt-suffix-part> ::= "Sr." | "Jr." | <roman-numeral> | "";
+            <opt-apt-num> ::= <apt-num> | ""

--- a/tests/fixtures/postal_address.terminated.input.bnf
+++ b/tests/fixtures/postal_address.terminated.input.bnf
@@ -1,0 +1,13 @@
+ <postal-address> ::= <name-part> <street-address> <zip-part>;
+
+            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+                            | <personal-part> <name-part>;
+
+        <personal-part> ::= <initial> "." | <first-name>;
+
+        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
+
+            <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>;
+
+        <opt-suffix-part> ::= "Sr." | "Jr." | <roman-numeral> | "";
+            <opt-apt-num> ::= <apt-num> | "";

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -14,43 +14,7 @@ struct Meta {
 
 // Modified version of BNF for BNF from
 // https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Further_examples
-const BNF_FOR_BNF: &str = "
-        <syntax>         ::= <rule> | <rule> <syntax>
-        <rule>           ::= <opt-whitespace> \"<\" <rule-name> \">\"
-                            <opt-whitespace> \"::=\" <opt-whitespace>
-                            <expression> <line-end>
-        <opt-whitespace> ::= \"\" | \" \" <opt-whitespace>
-        <expression>     ::= <list> | <list> <opt-whitespace> \"|\"
-                            <opt-whitespace> <expression>
-        <line-end>       ::= <opt-whitespace> <EOL>
-        <list>           ::= <term> | <term> <opt-whitespace> <list>
-        <term>           ::= <literal> | \"<\" <rule-name> \">\"
-        <literal>        ::= '\"' <text1> '\"' | \"'\" <text2> \"'\"
-        <text1>          ::= \"\" | <character1> <text1>
-        <text2>          ::= \"\" | <character2> <text2>
-        <character>      ::= <letter> | <digit> | <symbol>
-        <letter>         ::= \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\"
-                            | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\"
-                            | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\"
-                            | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\"
-                            | \"Y\" | \"Z\" | \"a\" | \"b\" | \"c\" | \"d\"
-                            | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\"
-                            | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\"
-                            | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\"
-                            | \"w\" | \"x\" | \"y\" | \"z\"
-        <digit>          ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\"
-                            | \"6\" | \"7\" | \"8\" | \"9\"
-        <symbol>         ::=  \"|\" | \" \" | \"-\" | \"!\" | \"#\" | \"$\"
-                            | \"%\" | \"&\" | \"(\" | \")\" | \"*\" | \"+\"
-                            | \",\" | \"-\" | \".\" | \"/\" | \":\" | \";\"
-                            |\">\" | \"=\" | \"<\" | \"?\" | \"@\" | \"[\"
-                            | \"\\\" | \"]\" | \"^\" | \"_\" | \"`\"
-                            | \"{{\" | \"}}\" | \"~\"
-        <character1>     ::= <character> | \"'\"
-        <character2>     ::= <character> | '\"'
-        <rule-name>      ::= <letter> | <rule-name> <rule-char>
-        <rule-char>      ::= <letter> | <digit> | \"-\"
-        <EOL>            ::= \"\n\"";
+const BNF_FOR_BNF: &str = std::include_str!("./fixtures/bnf.bnf");
 
 impl Arbitrary for Meta {
     fn arbitrary(_: &mut Gen) -> Meta {


### PR DESCRIPTION
This should partially address the suggestion in #79, splitting the longish, more escape-heavy bnf test fixtures into their own `.bnf` files. I decided against extracting the DNA example since it's short and emoji-based bnf examples since I didn't feel the effort would make reading the tests easier.