### PR TITLE
Add "+" operator

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::slice;
 use std::str::FromStr;
+use std::ops;
 use term::Term;
 
 /// An Expression is comprised of any number of Terms
@@ -95,6 +96,32 @@ impl FromStr for Expression {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
+    }
+}
+
+impl ops::BitOr<Expression> for Expression {
+    type Output = Expression;
+    fn bitor(self, rhs: Expression) -> Self::Output {
+        let mut new_expression = Expression::new();
+        for t in self.terms_iter() {
+            new_expression.add_term(t.clone());
+        }
+        for t in rhs.terms_iter() {
+            new_expression.add_term(t.clone());
+        }
+        new_expression
+    }
+}
+
+impl ops::BitOr<Term> for Expression {
+    type Output = Expression;
+    fn bitor(self, rhs: Term) -> Self::Output {
+        let mut new_expression = Expression::new();
+        for t in self.terms_iter() {
+            new_expression.add_term(t.clone());
+        }
+        new_expression.add_term(rhs);
+        new_expression
     }
 }
 
@@ -281,5 +308,25 @@ mod tests {
             },
             Ok(s) => panic!("should should be Error::ParseError: {}", s),
         }
+    }
+
+    #[test]
+    fn or_operator() {
+        let t1: Term = Term::Terminal(String::from("terminal"));
+        let nt1: Term = Term::Nonterminal(String::from("nonterminal"));
+        let t2: Term = Term::Terminal(String::from("terminal"));
+        let nt2: Term = Term::Nonterminal(String::from("nonterminal"));
+        let t3: Term = Term::Terminal(String::from("terminal"));
+        let nt3: Term = Term::Nonterminal(String::from("nonterminal"));
+
+        let e1 = Expression::from_parts(vec![nt1, t1]);
+        let e2_1 = Expression::from_parts(vec![nt2]);
+        let e2_2 = Expression::from_parts(vec![t2]);
+        let e2 = e2_1 | e2_2;
+        let e3_1 = Expression::from_parts(vec![nt3]);
+        let e3 = e3_1 | t3;
+
+        assert_eq!(e1, e2);
+        assert_eq!(e1, e3);
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -329,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn or_operator() {
+    fn add_operator() {
         let t1 = Term::Terminal(String::from("terminal"));
         let nt1 = Term::Nonterminal(String::from("nonterminal"));
         let t2 = Term::Terminal(String::from("terminal"));

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -99,7 +99,7 @@ impl FromStr for Expression {
     }
 }
 
-impl ops::BitOr<Expression> for Expression {
+impl ops::BitOr<Expression> for &Expression {
     type Output = Expression;
     fn bitor(self, rhs: Expression) -> Self::Output {
         let mut new_expression = Expression::new();
@@ -113,7 +113,7 @@ impl ops::BitOr<Expression> for Expression {
     }
 }
 
-impl ops::BitOr<Term> for Expression {
+impl ops::BitOr<Term> for &Expression {
     type Output = Expression;
     fn bitor(self, rhs: Term) -> Self::Output {
         let mut new_expression = Expression::new();
@@ -122,6 +122,24 @@ impl ops::BitOr<Term> for Expression {
         }
         new_expression.add_term(rhs);
         new_expression
+    }
+}
+
+impl ops::BitOr<Expression> for Expression {
+    type Output = Expression;
+    fn bitor(mut self, rhs: Expression) -> Self::Output {
+        for t in rhs.terms_iter() {
+            self.add_term(t.clone());
+        }
+        self
+    }
+}
+
+impl ops::BitOr<Term> for Expression {
+    type Output = Expression;
+    fn bitor(mut self, rhs: Term) -> Self::Output {
+        self.add_term(rhs);
+        self
     }
 }
 
@@ -312,21 +330,36 @@ mod tests {
 
     #[test]
     fn or_operator() {
-        let t1: Term = Term::Terminal(String::from("terminal"));
-        let nt1: Term = Term::Nonterminal(String::from("nonterminal"));
-        let t2: Term = Term::Terminal(String::from("terminal"));
-        let nt2: Term = Term::Nonterminal(String::from("nonterminal"));
-        let t3: Term = Term::Terminal(String::from("terminal"));
-        let nt3: Term = Term::Nonterminal(String::from("nonterminal"));
+        let t1 = Term::Terminal(String::from("terminal"));
+        let nt1 = Term::Nonterminal(String::from("nonterminal"));
+        let t2 = Term::Terminal(String::from("terminal"));
+        let nt2 = Term::Nonterminal(String::from("nonterminal"));
+        let t3 = Term::Terminal(String::from("terminal"));
+        let nt3 = Term::Nonterminal(String::from("nonterminal"));
+        let t4 = Term::Terminal(String::from("terminal"));
+        let nt4 = Term::Nonterminal(String::from("nonterminal"));
+        let t5 = Term::Terminal(String::from("terminal"));
+        let nt5 = Term::Nonterminal(String::from("nonterminal"));
 
         let e1 = Expression::from_parts(vec![nt1, t1]);
+
         let e2_1 = Expression::from_parts(vec![nt2]);
         let e2_2 = Expression::from_parts(vec![t2]);
         let e2 = e2_1 | e2_2;
+        
         let e3_1 = Expression::from_parts(vec![nt3]);
         let e3 = e3_1 | t3;
 
+        let mut e4_1 = Expression::from_parts(vec![nt4]);
+        let e4_2 = Expression::from_parts(vec![t4]);
+        let e4 = e4_1 | e4_2;
+        
+        let mut e5_1 = Expression::from_parts(vec![nt5]);
+        let e5 = e5_1 | t5;
+
         assert_eq!(e1, e2);
         assert_eq!(e1, e3);
+        assert_eq!(e1, e4);
+        assert_eq!(e1, e5);
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -102,7 +102,6 @@ impl FromStr for Expression {
 impl ops::Add<Expression> for &Expression {
     type Output = Expression;
     fn add(self, rhs: Expression) -> Self::Output {
-        println!("expression for & expression");
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -117,7 +116,6 @@ impl ops::Add<Expression> for &Expression {
 impl ops::Add<Term> for &Expression {
     type Output = Expression;
     fn add(self, rhs: Term) -> Self::Output {
-        println!("Term for & expression");
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -130,7 +128,6 @@ impl ops::Add<Term> for &Expression {
 impl ops::Add<Expression> for Expression {
     type Output = Expression;
     fn add(mut self, rhs: Expression) -> Self::Output {
-        println!("expression for mut expression");
         for t in rhs.terms_iter() {
             self.add_term(t.clone());
         }
@@ -141,7 +138,6 @@ impl ops::Add<Expression> for Expression {
 impl ops::Add<Term> for Expression {
     type Output = Expression;
     fn add(mut self, rhs: Term) -> Self::Output {
-        println!("term for mut expression");
         self.add_term(rhs);
         self
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -102,6 +102,7 @@ impl FromStr for Expression {
 impl ops::Add<Expression> for &Expression {
     type Output = Expression;
     fn add(self, rhs: Expression) -> Self::Output {
+        println!("expression for & expression");
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -116,6 +117,7 @@ impl ops::Add<Expression> for &Expression {
 impl ops::Add<Term> for &Expression {
     type Output = Expression;
     fn add(self, rhs: Term) -> Self::Output {
+        println!("Term for & expression");
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -128,6 +130,7 @@ impl ops::Add<Term> for &Expression {
 impl ops::Add<Expression> for Expression {
     type Output = Expression;
     fn add(mut self, rhs: Expression) -> Self::Output {
+        println!("expression for mut expression");
         for t in rhs.terms_iter() {
             self.add_term(t.clone());
         }
@@ -138,6 +141,7 @@ impl ops::Add<Expression> for Expression {
 impl ops::Add<Term> for Expression {
     type Output = Expression;
     fn add(mut self, rhs: Term) -> Self::Output {
+        println!("term for mut expression");
         self.add_term(rhs);
         self
     }
@@ -342,19 +346,19 @@ mod tests {
         let nt5 = Term::Nonterminal(String::from("nonterminal"));
 
         let e1 = Expression::from_parts(vec![nt1, t1]);
-
+        // &expression + expression
         let e2_1 = Expression::from_parts(vec![nt2]);
         let e2_2 = Expression::from_parts(vec![t2]);
-        let e2 = e2_1 + e2_2;
-
+        let e2 = &e2_1 + e2_2;
+        // &expression + term
         let e3_1 = Expression::from_parts(vec![nt3]);
-        let e3 = e3_1 + t3;
-
-        let mut e4_1 = Expression::from_parts(vec![nt4]);
+        let e3 = &e3_1 + t3;
+        // expression + expression
+        let e4_1 = Expression::from_parts(vec![nt4]);
         let e4_2 = Expression::from_parts(vec![t4]);
         let e4 = e4_1 + e4_2;
-
-        let mut e5_1 = Expression::from_parts(vec![nt5]);
+        // expression + term
+        let e5_1 = Expression::from_parts(vec![nt5]);
         let e5 = e5_1 + t5;
 
         assert_eq!(e1, e2);

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -2,9 +2,9 @@ use error::Error;
 use parsers;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::ops;
 use std::slice;
 use std::str::FromStr;
-use std::ops;
 use term::Term;
 
 /// An Expression is comprised of any number of Terms
@@ -346,14 +346,14 @@ mod tests {
         let e2_1 = Expression::from_parts(vec![nt2]);
         let e2_2 = Expression::from_parts(vec![t2]);
         let e2 = e2_1 | e2_2;
-        
+
         let e3_1 = Expression::from_parts(vec![nt3]);
         let e3 = e3_1 | t3;
 
         let mut e4_1 = Expression::from_parts(vec![nt4]);
         let e4_2 = Expression::from_parts(vec![t4]);
         let e4 = e4_1 | e4_2;
-        
+
         let mut e5_1 = Expression::from_parts(vec![nt5]);
         let e5 = e5_1 | t5;
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -99,9 +99,9 @@ impl FromStr for Expression {
     }
 }
 
-impl ops::BitOr<Expression> for &Expression {
+impl ops::Add<Expression> for &Expression {
     type Output = Expression;
-    fn bitor(self, rhs: Expression) -> Self::Output {
+    fn add(self, rhs: Expression) -> Self::Output {
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -113,9 +113,9 @@ impl ops::BitOr<Expression> for &Expression {
     }
 }
 
-impl ops::BitOr<Term> for &Expression {
+impl ops::Add<Term> for &Expression {
     type Output = Expression;
-    fn bitor(self, rhs: Term) -> Self::Output {
+    fn add(self, rhs: Term) -> Self::Output {
         let mut new_expression = Expression::new();
         for t in self.terms_iter() {
             new_expression.add_term(t.clone());
@@ -125,9 +125,9 @@ impl ops::BitOr<Term> for &Expression {
     }
 }
 
-impl ops::BitOr<Expression> for Expression {
+impl ops::Add<Expression> for Expression {
     type Output = Expression;
-    fn bitor(mut self, rhs: Expression) -> Self::Output {
+    fn add(mut self, rhs: Expression) -> Self::Output {
         for t in rhs.terms_iter() {
             self.add_term(t.clone());
         }
@@ -135,9 +135,9 @@ impl ops::BitOr<Expression> for Expression {
     }
 }
 
-impl ops::BitOr<Term> for Expression {
+impl ops::Add<Term> for Expression {
     type Output = Expression;
-    fn bitor(mut self, rhs: Term) -> Self::Output {
+    fn add(mut self, rhs: Term) -> Self::Output {
         self.add_term(rhs);
         self
     }
@@ -345,17 +345,17 @@ mod tests {
 
         let e2_1 = Expression::from_parts(vec![nt2]);
         let e2_2 = Expression::from_parts(vec![t2]);
-        let e2 = e2_1 | e2_2;
+        let e2 = e2_1 + e2_2;
 
         let e3_1 = Expression::from_parts(vec![nt3]);
-        let e3 = e3_1 | t3;
+        let e3 = e3_1 + t3;
 
         let mut e4_1 = Expression::from_parts(vec![nt4]);
         let e4_2 = Expression::from_parts(vec![t4]);
-        let e4 = e4_1 | e4_2;
+        let e4 = e4_1 + e4_2;
 
         let mut e5_1 = Expression::from_parts(vec![nt5]);
-        let e5 = e5_1 | t5;
+        let e5 = e5_1 + t5;
 
         assert_eq!(e1, e2);
         assert_eq!(e1, e3);

--- a/src/term.rs
+++ b/src/term.rs
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn or_operator() {
+    fn add_operator() {
         let t1 = Term::Terminal(String::from("terminal"));
         let nt1 = Term::Nonterminal(String::from("nonterminal"));
         let t2 = Term::Terminal(String::from("terminal"));

--- a/src/term.rs
+++ b/src/term.rs
@@ -25,25 +25,25 @@ impl FromStr for Term {
     }
 }
 
-impl ops::BitOr<Term> for Term {
+impl ops::Add<Term> for Term {
     type Output = Expression;
 
-    fn bitor(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: Self) -> Self::Output {
         Expression::from_parts(vec![self, rhs])
     }
 }
 
-impl ops::BitOr<Expression> for Term {
+impl ops::Add<Expression> for Term {
     type Output = Expression;
-    fn bitor(self, mut rhs: Expression) -> Self::Output {
+    fn add(self, mut rhs: Expression) -> Self::Output {
         rhs.add_term(self);
         rhs
     }
 }
 
-impl ops::BitOr<&Expression> for Term {
+impl ops::Add<&Expression> for Term {
     type Output = Expression;
-    fn bitor(self, rhs: &Expression) -> Self::Output {
+    fn add(self, rhs: &Expression) -> Self::Output {
         let mut new = Expression::new();
         for t in rhs.terms_iter() {
             new.add_term(t.clone());
@@ -198,11 +198,11 @@ mod tests {
         let nt4 = Term::Nonterminal(String::from("nonterminal"));
 
         let e1 = Expression::from_parts(vec![nt1, t1]);
-        let e2 = nt2 | t2;
+        let e2 = nt2 + t2;
         let e3_1 = Expression::from_parts(vec![nt3]);
-        let e3 = t3 | e3_1;
+        let e3 = t3 + e3_1;
         let mut e4_1 = Expression::from_parts(vec![nt4]);
-        let e4 = t4 | e4_1;
+        let e4 = t4 + e4_1;
 
         // Term get's pushed to the end of expression.
         // functionally identical, but different to eq

--- a/src/term.rs
+++ b/src/term.rs
@@ -197,11 +197,14 @@ mod tests {
         let t4 = Term::Terminal(String::from("terminal"));
         let nt4 = Term::Nonterminal(String::from("nonterminal"));
 
+        // term + term
         let e1 = Expression::from_parts(vec![nt1, t1]);
         let e2 = nt2 + t2;
+        // term + &expression
         let e3_1 = Expression::from_parts(vec![nt3]);
-        let e3 = t3 + e3_1;
-        let mut e4_1 = Expression::from_parts(vec![nt4]);
+        let e3 = t3 + &e3_1;
+        //term + expression
+        let e4_1 = Expression::from_parts(vec![nt4]);
         let e4 = t4 + e4_1;
 
         // Term get's pushed to the end of expression.

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::should_implement_trait)]
 
 use error::Error;
+use expression::Expression;
 use parsers;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::str::FromStr;
 use std::ops;
-use expression::Expression;
+use std::str::FromStr;
 
 /// A Term can represent a Terminal or Nonterminal node
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/term.rs
+++ b/src/term.rs
@@ -35,14 +35,21 @@ impl ops::BitOr<Term> for Term {
 
 impl ops::BitOr<Expression> for Term {
     type Output = Expression;
+    fn bitor(self, mut rhs: Expression) -> Self::Output {
+        rhs.add_term(self);
+        rhs
+    }
+}
 
-    fn bitor(self, rhs: Expression) -> Self::Output {
-        let mut new_expression = Expression::new();
+impl ops::BitOr<&Expression> for Term {
+    type Output = Expression;
+    fn bitor(self, rhs: &Expression) -> Self::Output {
+        let mut new = Expression::new();
         for t in rhs.terms_iter() {
-            new_expression.add_term(t.clone());
+            new.add_term(t.clone());
         }
-        new_expression.add_term(self);
-        new_expression
+        new.add_term(self);
+        new
     }
 }
 
@@ -181,19 +188,29 @@ mod tests {
 
     #[test]
     fn or_operator() {
-        let t1: Term = Term::Terminal(String::from("terminal"));
-        let nt1: Term = Term::Nonterminal(String::from("nonterminal"));
-        let t2: Term = Term::Terminal(String::from("terminal"));
-        let nt2: Term = Term::Nonterminal(String::from("nonterminal"));
-        let t3: Term = Term::Terminal(String::from("terminal"));
-        let nt3: Term = Term::Nonterminal(String::from("nonterminal"));
+        let t1 = Term::Terminal(String::from("terminal"));
+        let nt1 = Term::Nonterminal(String::from("nonterminal"));
+        let t2 = Term::Terminal(String::from("terminal"));
+        let nt2 = Term::Nonterminal(String::from("nonterminal"));
+        let t3 = Term::Terminal(String::from("terminal"));
+        let nt3 = Term::Nonterminal(String::from("nonterminal"));
+        let t4 = Term::Terminal(String::from("terminal"));
+        let nt4 = Term::Nonterminal(String::from("nonterminal"));
 
-        let e1: Expression = Expression::from_parts(vec![nt1, t1]);
-        let e2: Expression = nt2 | t2;
-        let e3_1: Expression = Expression::from_parts(vec![t3]);
-        let e3: Expression = nt3 | e3_1;
+        let e1 = Expression::from_parts(vec![nt1, t1]);
+        let e2 = nt2 | t2;
+        let e3_1 = Expression::from_parts(vec![nt3]);
+        let e3 = t3 | e3_1;
+        let mut e4_1 = Expression::from_parts(vec![nt4]);
+        let e4 = t4 | e4_1;
+
+        // Term get's pushed to the end of expression.
+        // functionally identical, but different to eq
+        // example:
+        // nt3 | Expression::from_parts(vec![t3]) != Expression::from_parts(vec![nt3, t3])
 
         assert_eq!(e1, e2);
         assert_eq!(e1, e3);
+        assert_eq!(e1, e4);
     }
 }


### PR DESCRIPTION
I implemented the BitOr Trait (`|` operator) for Term and Expression as described in #34.
This allows syntax that mirrors actual BNF like:
`let exp= Term::Terminal::from_str("A") | Term::Terminal::from_str("B") | Term::Terminal::from_str("C")`

- `Term | Term` creates an Expression that contains both Terms.
- `Expression | Term` and `Term | Expression` add the Term to the Expression.
- `Expression1 | Expression2` clones all terms from Expression2 and adds them to Expression1

I made seperate methods for `Expression` and `&Expression` to prevent unnecessary clones as recommended in  https://doc.rust-lang.org/core/ops/index.html

While testing, I noticed that two expressions are only counted as equal when their .terms are in the exact same order.
This causes strange behavior like:
`a | Expression::from_parts(vec![b,c]) != Expression::from_parts(vec![a,b,c])`
This should probably be a new Issue, but the implementation for `Term | Expression` would have to be changed if this is intentional.