### PR TITLE
Benchmark BNF examples via Criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,10 @@ version = "1.0.61"
 
 [dev-dependencies.quickcheck]
 version = "1.0.2"
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "bnf"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,32 @@
+# Benchmarking
+
+Benchmarking numbers will vary across tests, specific grammars, rust versions, and hardware. With so many sources of noise, it is important to remember that "faster" is not always easy to define.
+
+With that in mind, BNF's benchmarking has the following goals:
+* identify statistically significant performance regressions
+* validate performance hypothesis
+
+These benchmarks are not run during continuous integration testing. But if a developer is attempting a full overhaul of the BNF parser, these benchmarks will help them identify large changes in performance.
+
+## How to Run
+
+> cargo bench
+
+## Criterion
+
+[Criterion][criterion] is used to run benchmarks with confidence. Criterion achieves this by running warmups, collecting a statistically significant sized sample, and generating informative reports.
+
+## Cargo Criterion
+
+[cargo-criterion][cargo-criterion] is a plugin for Cargo which handles much of the heavy lifting for analyzing and reporting on Criterion-rs benchmarks. It eases generating performance report files.
+
+### Install
+
+> cargo install cargo-criterion
+
+### How To Run
+
+> cargo criterion
+
+[criterion]: https://crates.io/crates/criterion
+[cargo-criterion]: https://github.com/bheisler/cargo-criterion

--- a/benches/bnf.rs
+++ b/benches/bnf.rs
@@ -10,10 +10,8 @@ fn examples(c: &mut Criterion) {
     c.bench_function("generate DNA", |b| {
         let input = "<dna> ::= <base> | <base> <dna>
             <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
-        b.iter(|| {
-            let grammar: Grammar = input.parse().unwrap();
-            grammar.generate().unwrap();
-        });
+        let grammar: Grammar = input.parse().unwrap();
+        b.iter(|| grammar.generate().unwrap());
     });
 }
 

--- a/benches/bnf.rs
+++ b/benches/bnf.rs
@@ -1,0 +1,21 @@
+use bnf::Grammar;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn examples(c: &mut Criterion) {
+    c.bench_function("parse postal", |b| {
+        let input = std::include_str!("../tests/fixtures/postal_address.terminated.input.bnf");
+        b.iter(|| input.parse::<Grammar>().unwrap());
+    });
+
+    c.bench_function("generate DNA", |b| {
+        let input = "<dna> ::= <base> | <base> <dna>
+            <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+        b.iter(|| {
+            let grammar: Grammar = input.parse().unwrap();
+            grammar.generate().unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, examples);
+criterion_main!(benches);


### PR DESCRIPTION
# Changes

I hope the [README](https://github.com/shnewto/bnf/pull/91/files#diff-a78b465f9dbab9f55bce48f68761be8cef21f8dc2501840b833524cd9c8f7551) explains this PR. But one additional nice thing to look at is a screenshot from the Criterion report 😍 

<img width="940" alt="image" src="https://user-images.githubusercontent.com/5395183/166824435-563fe0ca-1964-4b89-a832-0d13984fd6fd.png">

Obviously big caveat to the numbers. Running on my personal laptop, with other process activity, etc. But nice to see what the reports can look like!

# Issues

One potential issue with these benchmarks is that `Grammar::generate` relies on random seeds. Currently there is no public API for generating with a static, controlled seed for reliable benchmarking. This introduces some chance to that benchmark, but hopefully it is small noise in the big picture. On my machine, I observed ~2% of performance drift between random `Grammar::generate` benchmarks.