### PR TITLE
bump actions/checkout major version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -29,7 +29,7 @@ jobs:
     needs: [format]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -44,7 +44,7 @@ jobs:
     needs: [format]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -59,7 +59,7 @@ jobs:
     needs: [format]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -74,7 +74,7 @@ jobs:
     needs: [format]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -89,7 +89,7 @@ jobs:
     needs: [format]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -116,7 +116,7 @@ jobs:
     needs: [format]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
noticed some out of date info in the actions/checkout v1 and would like to see if its updated in v3

