### PR TITLE
mermaid formatting of parse trees

### DIFF
--- a/src/earley.rs
+++ b/src/earley.rs
@@ -78,7 +78,7 @@ impl<'gram> Grammar<'gram> {
             .map(|p| (p.lhs, p.rhs))
             .expect("invalid Production ID")
     }
-    /// Get `Production` by the LHS `Term (useful when predicting new `State`)
+    /// Get `Production` by the LHS `Term` (useful when predicting new `State`)
     pub fn get_productions_by_lhs(
         &self,
         lhs: &'gram Term,
@@ -157,7 +157,7 @@ impl<'gram> InputRange<'gram> {
 }
 
 /// A clear view of `InputRange`, in the format "InputRange(before | current | after)"
-/// e.g., "InputRange(["1", "+", "("] | ["2"] | ["*", "3", "-", "4", ")"])"
+/// e.g., "`InputRange`(["1", "+", "("] | ["2"] | ["*", "3", "-", "4", ")"])"
 impl<'gram> std::fmt::Debug for InputRange<'gram> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let before = &self.input[..self.start];

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -17,6 +17,7 @@ pub enum ParseTreeNode<'gram> {
     Nonterminal(ParseTree<'gram>),
 }
 
+/// A tree derived by successing parsing an input string via [`Grammar::parse_input`]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseTree<'gram> {
     pub lhs: &'gram Term,
@@ -145,6 +146,20 @@ impl<'gram> ParseTree<'gram> {
         Ok(())
     }
 
+    /// Opt into formatting as [Mermaid.js](https://mermaid-js.github.io/) flowchart.
+    ///
+    /// ```
+    /// # use bnf::Grammar;
+    /// let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
+    /// <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+    /// .parse()
+    /// .unwrap();
+    ///
+    /// let input = "GATTACA";
+    /// let parsed = grammar.parse_input(input).next().unwrap();
+    /// let mermaid = parsed.mermaid().to_string();
+    /// println!("parse tree mermaid: {}", mermaid);
+    /// ```
     pub fn mermaid(&self) -> MermaidParseTree<'_> {
         MermaidParseTree { parse_tree: self }
     }
@@ -169,6 +184,8 @@ impl<'gram> fmt::Display for ParseTree<'gram> {
     }
 }
 
+/// Wrap `ParseTree` in "Mermaid" type, which opts into new implementation of `std::fmt::Display`.
+/// Writes `ParseTree` as [Mermaid.js](https://mermaid-js.github.io/) flowchart.
 pub struct MermaidParseTree<'a> {
     parse_tree: &'a ParseTree<'a>,
 }
@@ -190,7 +207,7 @@ impl<'a> MermaidParseTree<'a> {
 
         let lhs_count = *count;
 
-        for rhs in self.parse_tree.rhs.iter() {
+        for rhs in &self.parse_tree.rhs {
             *count += 1;
             match rhs {
                 ParseTreeNode::Terminal(rhs) => {


### PR DESCRIPTION
This adds mermaid output for parse trees. Honestly, not sure if useful enough to warrant being merged. But it sure is nice to include in github docs, such as PRs!

```mermaid
flowchart TD
0["sum"] --> 1["sum"]
1["sum"] --> 2["product"]
2["product"] --> 3["factor"]
3["factor"] --> 4["number"]
4["number"] --> 5["digit"]
5["digit"] --> 6["1"]
0["sum"] --> 7["add"]
7["add"] --> 8["+"]
0["sum"] --> 9["product"]
9["product"] --> 10["factor"]
10["factor"] --> 11["("]
10["factor"] --> 12["sum"]
12["sum"] --> 13["sum"]
13["sum"] --> 14["product"]
14["product"] --> 15["product"]
15["product"] --> 16["factor"]
16["factor"] --> 17["number"]
17["number"] --> 18["digit"]
18["digit"] --> 19["2"]
14["product"] --> 20["mult"]
20["mult"] --> 21["*"]
14["product"] --> 22["factor"]
22["factor"] --> 23["number"]
23["number"] --> 24["digit"]
24["digit"] --> 25["3"]
12["sum"] --> 26["add"]
26["add"] --> 27["-"]
12["sum"] --> 28["product"]
28["product"] --> 29["factor"]
29["factor"] --> 30["number"]
30["number"] --> 31["digit"]
31["digit"] --> 32["4"]
10["factor"] --> 33[")"]
```

## Implementation

each node gets assigned a unique, auto incrementing ID. But instead of displaying that ID in the Mermaid diagram, use the `Term` string.

## Dangers

I do think this draft implementation can produce invalid input. Because BNF allows for arbitrary tokens in `Term`s, Mermaid expects some of those characters to be escaped.

I am not sure if the right next step is to build a "fully compliant" Mermaid filter layer, or maybe just accept that some grammars may not build parse trees that Mermaid can parse.