### PR TITLE
full README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![coveralls](https://coveralls.io/repos/github/shnewto/bnf/badge.svg?branch=main)](https://coveralls.io/github/shnewto/bnf?branch=main)
 [![Crates.io Version](https://img.shields.io/crates/v/bnf.svg)](https://crates.io/crates/bnf)
 [![Crates.io](https://img.shields.io/crates/d/bnf.svg)](https://crates.io/crates/bnf)
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/shnewto/bnf/blob/main/LICENSE)
 
 A library for parsing Backus–Naur form context-free grammars.
 


### PR DESCRIPTION
IDK how I missed this before during #96, but rustdoc gives a warning on the `LICENSE` link. The link does actually work! But I think rustdoc gets confused by "shorthand" link paths `(LICENSE)` because there _could_ be a rust doc item by the same name.

rustdoc does *not* get confused by explicit URL paths tho, so this updates the LICENSE link to use the full URL