### PR TITLE
generic slice iterator w/ size hints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnf"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2021"
 authors = ["@shnewto", "@CrockAgile", "@androm3da", "@sremedios", "@prbs23", "@z2oh",
 "@lionel1704", "@benarmstead", "@jonay2000", "@SKalt", "@DrunkJon"]

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -57,16 +57,14 @@ impl Expression {
     }
 
     /// Get iterator of `Term`s within `Expression`
-    pub fn terms_iter(&self) -> Iter {
-        Iter {
-            slice: &self.terms[..],
-        }
+    pub fn terms_iter(&self) -> impl Iterator<Item = &Term> {
+        crate::slice_iter::SliceIter { slice: &self.terms }
     }
 
     /// Get mutable iterator of `Term`s within `Expression`
-    pub fn terms_iter_mut(&mut self) -> IterMut {
-        IterMut {
-            slice: &mut self.terms[..],
+    pub fn terms_iter_mut(&mut self) -> impl Iterator<Item = &mut Term> {
+        crate::slice_iter::SliceIterMut {
+            slice: &mut self.terms,
         }
     }
 }
@@ -136,40 +134,6 @@ impl ops::Add<Term> for Expression {
     fn add(mut self, rhs: Term) -> Self::Output {
         self.add_term(rhs);
         self
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Iter<'a> {
-    slice: &'a [Term],
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Term;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.slice.split_first().map(|(first, rest)| {
-            self.slice = rest;
-            first
-        })
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct IterMut<'a> {
-    slice: &'a mut [Term],
-}
-
-impl<'a> Iterator for IterMut<'a> {
-    type Item = &'a mut Term;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let slice = std::mem::take(&mut self.slice);
-
-        slice.split_first_mut().map(|(first, rest)| {
-            self.slice = rest;
-            first
-        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod expression;
 mod grammar;
 mod parsers;
 mod production;
+mod slice_iter;
 mod term;
 pub use crate::error::Error;
 pub use crate::expression::Expression;

--- a/src/production.rs
+++ b/src/production.rs
@@ -48,16 +48,14 @@ impl Production {
     }
 
     /// Get iterator of the `Production`'s right hand side `Expression`s
-    pub fn rhs_iter(&self) -> Iter {
-        Iter {
-            slice: &self.rhs[..],
-        }
+    pub fn rhs_iter(&self) -> impl Iterator<Item = &Expression> {
+        crate::slice_iter::SliceIter { slice: &self.rhs }
     }
 
     /// Get mutable iterator of the `Production`'s right hand side `Expression`s
-    pub fn rhs_iter_mut(&mut self) -> IterMut {
-        IterMut {
-            slice: &mut self.rhs[..],
+    pub fn rhs_iter_mut(&mut self) -> impl Iterator<Item = &mut Expression> {
+        crate::slice_iter::SliceIterMut {
+            slice: &mut self.rhs,
         }
     }
 
@@ -100,40 +98,6 @@ impl FromStr for Production {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Iter<'a> {
-    slice: &'a [Expression],
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Expression;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.slice.split_first().map(|(first, rest)| {
-            self.slice = rest;
-            first
-        })
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct IterMut<'a> {
-    slice: &'a mut [Expression],
-}
-
-impl<'a> Iterator for IterMut<'a> {
-    type Item = &'a mut Expression;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let slice = std::mem::take(&mut self.slice);
-
-        slice.split_first_mut().map(|(first, rest)| {
-            self.slice = rest;
-            first
-        })
     }
 }
 

--- a/src/slice_iter.rs
+++ b/src/slice_iter.rs
@@ -1,0 +1,43 @@
+/// Generic Iterator wrapper of slice
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SliceIter<'a, T> {
+    pub(crate) slice: &'a [T],
+}
+
+impl<'a, T> Iterator for SliceIter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.slice.split_first().map(|(first, rest)| {
+            self.slice = rest;
+            first
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.slice.len();
+        (size, Some(size))
+    }
+}
+
+/// Generic Iterator wrapper of mutable slice
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SliceIterMut<'a, T> {
+    pub(crate) slice: &'a mut [T],
+}
+
+impl<'a, T> Iterator for SliceIterMut<'a, T> {
+    type Item = &'a mut T;
+    fn next(&mut self) -> Option<Self::Item> {
+        let rhs_nodes = std::mem::take(&mut self.slice);
+
+        rhs_nodes.split_first_mut().map(|(first, rest)| {
+            self.slice = rest;
+            first
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.slice.len();
+        (size, Some(size))
+    }
+}


### PR DESCRIPTION
This PR adds support for size hints, which closes #94

But also while working on it, I realized I had introduced a lot of bespoke iterator types with duplicate code.

Luckily Rust has generics! So this adds a new utility `SliceIter` generic type, reducing code 🎊 

## Dangers

There is one sad danger with this. It is a breaking change! The public iterator types were exposed previously (e.g. `fn iter_rhs() -> CustomIter`).  This allows users to potentially rely on an explicit iterator type.

To prevent this in the future, return types have been updated to more opaque anonymous iterator types (e.g. `fn iter_rhs() -> impl Iterator<Item = &Term>`). That way, any future iterator changes should *not* be a breaking change.