### PR TITLE
Expose ParseTreeNode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,6 @@ mod slice_iter;
 mod term;
 pub use crate::error::Error;
 pub use crate::expression::Expression;
-pub use crate::grammar::{Grammar, ParseTree};
+pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;


### PR DESCRIPTION
Exposes `ParseTreeNode` to allow full matching of `ParseTree`s. Before, outputs of parsing couldn't be fully accessed because of the inability of construct variants of `ParseTreeNode` to match. Now, variants can be constructed and used for matching the `ParseTreeNode` enum, fully exposing `ParseTree`.
