### PR TITLE
Clean iter mut pattern

### DIFF
--- a/src/slice_iter.rs
+++ b/src/slice_iter.rs
@@ -28,12 +28,13 @@ pub(crate) struct SliceIterMut<'a, T> {
 impl<'a, T> Iterator for SliceIterMut<'a, T> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<Self::Item> {
-        let rhs_nodes = std::mem::take(&mut self.slice);
-
-        rhs_nodes.split_first_mut().map(|(first, rest)| {
-            self.slice = rest;
-            first
-        })
+        match std::mem::take(&mut self.slice) {
+            [] => None,
+            [first, rest @ ..] => {
+                self.slice = rest;
+                Some(first)
+            }
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
This is not a bug fix, and criterion saw no performance change. I saw this pattern in some code the other day and thought it was more clear. Maybe subjective!
