### PR TITLE
fix implicit lifetime clippy warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ mod tests {
     use crate::error::Error;
     use nom::{bytes::complete::tag, error::VerboseError, Err, IResult};
 
-    fn give_error_kind<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+    fn give_error_kind(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
         let (input, _) = tag("1234")(input)?;
         let (input, res) = tag("5678")(input)?;
         Ok((input, res))

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -131,7 +131,7 @@ impl<'gram> ParseTree<'gram> {
     }
 
     /// Iterate the "right hand side" parse tree nodes
-    pub fn rhs_iter<'a>(&'a self) -> impl Iterator<Item = &'a ParseTreeNode> {
+    pub fn rhs_iter(&self) -> impl Iterator<Item = &ParseTreeNode> {
         crate::slice_iter::SliceIter { slice: &self.rhs }
     }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -73,7 +73,7 @@ pub fn term_complete(input: &str) -> IResult<&str, Term, VerboseError<&str>> {
     Ok((input, t))
 }
 
-pub fn expression_next<'a>(input: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+pub fn expression_next(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
     let (input, _) = preceded(
         complete::multispace0,
         terminated(complete::char('|'), complete::multispace0),


### PR DESCRIPTION
clippy has a few new suggestions to remove explicit lifetime annotations in favor of implicit lifetimes