### PR TITLE
Complete prior Earley predictions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 
 [dependencies]
 tracing = { version = "0.1.37", optional = true }
-tracing-subscriber = { version = "0.3.16", optional = true }
+tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }
 tracing-flame = { version = "0.2.0", optional = true }
 
 [dependencies.stacker]

--- a/src/earley/grammar.rs
+++ b/src/earley/grammar.rs
@@ -147,7 +147,7 @@ pub(crate) struct GrammarMatching<'gram> {
 
 impl<'gram, 'a> GrammarMatching<'gram> {
     pub fn new(grammar: &'gram crate::Grammar) -> Self {
-        let _span = tracing::span!(tracing::Level::TRACE, "GrammarMatching::new").entered();
+        let _span = tracing::span!(tracing::Level::TRACE, "GrammarMatching_new").entered();
 
         let mut productions = AppendOnlyVec::<Production, ProductionId>::new();
         let mut prods_by_lhs = ProdTermMap::new();

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -142,6 +142,8 @@ impl<'gram> Iterator for ParseIter<'gram> {
                 let _span = tracing::span!(tracing::Level::TRACE, "ParseIter::handler").entered();
                 let traversal = arena.get(id).expect("invalid traversal ID");
 
+                tracing::event!(tracing::Level::TRACE, "popped traversal: {traversal:#?}");
+
                 match traversal.earley() {
                     EarleyStep::Predict(nonterminal) => {
                         let _span = tracing::span!(tracing::Level::TRACE, "Predict").entered();

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -116,12 +116,20 @@ impl<'gram> ParseIter<'gram> {
         is_nullable_productions: bool,
     ) -> Self {
         let input_range = InputRange::new(input);
-        let traversal_queue = TraversalQueue::new(&grammar, input_range, starting_term);
         let null_match_map = if is_nullable_productions {
             find_null_prod_matches(grammar.clone())
         } else {
             NullMatchMap::new()
         };
+
+        if is_nullable_productions {
+            tracing::event!(
+                tracing::Level::TRACE,
+                "grammar nullable terms: {null_match_map:#?}"
+            );
+        }
+
+        let traversal_queue = TraversalQueue::new(&grammar, input_range, starting_term);
 
         Self {
             grammar,
@@ -136,10 +144,10 @@ impl<'gram> Iterator for ParseIter<'gram> {
     type Item = Rc<ProductionMatch<'gram>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let _span = tracing::span!(tracing::Level::TRACE, "ParseIter::next").entered();
+        let _span = tracing::span!(tracing::Level::TRACE, "ParseIter_new").entered();
         self.traversal_queue
             .handle_pop(|id, arena, incomplete, created| {
-                let _span = tracing::span!(tracing::Level::TRACE, "ParseIter::handler").entered();
+                let _span = tracing::span!(tracing::Level::TRACE, "ParseIter_handler").entered();
                 let traversal = arena.get(id).expect("invalid traversal ID");
 
                 tracing::event!(tracing::Level::TRACE, "popped traversal: {traversal:#?}");

--- a/src/earley/traversal.rs
+++ b/src/earley/traversal.rs
@@ -171,7 +171,20 @@ impl<'gram> TraversalQueue<'gram> {
         let _span = tracing::span!(tracing::Level::TRACE, "Queue::extend").entered();
         for traversal in traversals {
             let processed_key = traversal.duplicate_key();
+
             let is_new_traversal = self.processed.insert(processed_key);
+
+            let _new_traversal_prefix = if is_new_traversal {
+                "new traversal"
+            } else {
+                "ignored duplicate traversal"
+            };
+
+            tracing::event!(
+                tracing::Level::TRACE,
+                "{_new_traversal_prefix}: {:#?}",
+                traversal
+            );
 
             if !is_new_traversal {
                 continue;

--- a/src/earley/traversal.rs
+++ b/src/earley/traversal.rs
@@ -148,6 +148,8 @@ impl<'gram> TraversalQueue<'gram> {
         input_range: InputRange<'gram>,
         starting_term: &'gram Term,
     ) -> Self {
+        let _span = tracing::span!(tracing::Level::TRACE, "TraversalQueue_new").entered();
+
         let queue = VecDeque::new();
         let starting_traversals = grammar
             .get_productions_by_lhs(starting_term)
@@ -168,7 +170,7 @@ impl<'gram> TraversalQueue<'gram> {
     where
         I: Iterator<Item = Traversal<'gram>>,
     {
-        let _span = tracing::span!(tracing::Level::TRACE, "Queue::extend").entered();
+        let _span = tracing::span!(tracing::Level::TRACE, "TraversalQueue_extend").entered();
         for traversal in traversals {
             let processed_key = traversal.duplicate_key();
 
@@ -210,7 +212,7 @@ impl<'gram> TraversalQueue<'gram> {
             &mut Vec<Traversal<'gram>>,
         ) -> Option<Rc<ProductionMatch<'gram>>>,
     {
-        let _span = tracing::span!(tracing::Level::TRACE, "Queue::handle_pop").entered();
+        let _span = tracing::span!(tracing::Level::TRACE, "TraversalQueue_handle_pop").entered();
         let mut created = Vec::<Traversal>::new();
 
         while let Some(id) = self.queue.pop_front() {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -687,7 +687,6 @@ mod tests {
 
     #[test]
     fn shared_nonterminal_failure() {
-        crate::tracing::init_subscriber();
         let grammar = "
         <start> ::= <shortfail> | <longsuccess>
         <shortfail> ::= <char> 'never'
@@ -710,7 +709,6 @@ mod tests {
 
     #[test]
     fn swap_left_right_recursion() {
-        crate::tracing::init_subscriber();
         let input = "aa a";
 
         let left_recursive: &str = "

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -687,6 +687,7 @@ mod tests {
 
     #[test]
     fn issue() {
+        crate::tracing::init_subscriber();
         let input = "aa a";
 
         let left_recursive: &str = "

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -686,35 +686,53 @@ mod tests {
     }
 
     #[test]
-    fn issue() {
+    fn shared_nonterminal_failure() {
+        crate::tracing::init_subscriber();
+        let grammar = "
+        <start> ::= <shortfail> | <longsuccess>
+        <shortfail> ::= <char> 'never'
+        <char> ::= 'a'
+        <longsuccess> ::= <long2>
+        <long2> ::= <long3>
+        <long3> ::= <long4>
+        <long4> ::= <char>
+        ";
+
+        let grammar = grammar.parse::<Grammar>().unwrap();
+
+        let input = "a";
+
+        assert!(
+            grammar.parse_input(input).next().is_some(),
+            "minimal issue failed to parse: {input}"
+        );
+    }
+
+    #[test]
+    fn swap_left_right_recursion() {
         crate::tracing::init_subscriber();
         let input = "aa a";
 
         let left_recursive: &str = "
         <conjunction> ::= <conjunction> <ws> <predicate> | <predicate>
         <predicate> ::= <string_null_one> | <special-string> '.'
-    
         <string_null_one> ::= <string_null_two>
         <string_null_two> ::= <string_null_three>
         <string_null_three> ::= <string>
-    
         <string> ::= <char_null> | <string> <char_null>
         <special-string> ::= <special-char> | <special-string> <special-char>
-    
         <char_null> ::= <char>
         <char> ::= 'a'
-    
         <special-char> ::= <char_null> | <whitespace>
         <whitespace> ::= ' '
-    
         <ws> ::= ' ' | ' ' <ws>
         ";
-        // assert!(left_recursive
-        //     .parse::<Grammar>()
-        //     .unwrap()
-        //     .parse_input(input)
-        //     .next()
-        //     .is_some());
+        assert!(left_recursive
+            .parse::<Grammar>()
+            .unwrap()
+            .parse_input(input)
+            .next()
+            .is_some());
 
         let right_recursive = left_recursive.replace(
             // rewrite production from left- to right- recursive

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -709,12 +709,12 @@ mod tests {
     
         <ws> ::= ' ' | ' ' <ws>
         ";
-        assert!(left_recursive
-            .parse::<Grammar>()
-            .unwrap()
-            .parse_input(input)
-            .next()
-            .is_some());
+        // assert!(left_recursive
+        //     .parse::<Grammar>()
+        //     .unwrap()
+        //     .parse_input(input)
+        //     .next()
+        //     .is_some());
 
         let right_recursive = left_recursive.replace(
             // rewrite production from left- to right- recursive

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -686,6 +686,52 @@ mod tests {
     }
 
     #[test]
+    fn issue() {
+        let input = "aa a";
+
+        let left_recursive: &str = "
+        <conjunction> ::= <conjunction> <ws> <predicate> | <predicate>
+        <predicate> ::= <string_null_one> | <special-string> '.'
+    
+        <string_null_one> ::= <string_null_two>
+        <string_null_two> ::= <string_null_three>
+        <string_null_three> ::= <string>
+    
+        <string> ::= <char_null> | <string> <char_null>
+        <special-string> ::= <special-char> | <special-string> <special-char>
+    
+        <char_null> ::= <char>
+        <char> ::= 'a'
+    
+        <special-char> ::= <char_null> | <whitespace>
+        <whitespace> ::= ' '
+    
+        <ws> ::= ' ' | ' ' <ws>
+        ";
+        assert!(left_recursive
+            .parse::<Grammar>()
+            .unwrap()
+            .parse_input(input)
+            .next()
+            .is_some());
+
+        let right_recursive = left_recursive.replace(
+            // rewrite production from left- to right- recursive
+            "<string> ::= <char_null> | <string> <char_null>",
+            "<string> ::= <char_null> | <char_null> <string>",
+        );
+        assert!(
+            right_recursive
+                .parse::<Grammar>()
+                .unwrap()
+                .parse_input(input)
+                .next()
+                .is_some(),
+            "right-recursive grammar failed to parse: {input}"
+        );
+    }
+
+    #[test]
     fn format_parse_tree() {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
         <base> ::= \"A\" | \"C\" | \"G\" | \"T\""

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -751,6 +751,74 @@ mod tests {
     }
 
     #[test]
+    fn shared_nullable_nonterminal() {
+        let fails: &str = "
+        <disjunction> ::= <predicate> | <disjunction> <or> <predicate>
+        <predicate> ::= <char_null_one> | <special-string> '.'
+
+        <char_null_one> ::= <char_null_two>
+        <char_null_two> ::= <char_null_three>
+        <char_null_three> ::= <char>
+
+        <or> ::= <ws> 'or' <ws>
+        <ws> ::= <whitespace> | ' ' <ws>
+        <whitespace> ::= ' '
+
+        <special-string> ::= <special-char> | <special-char> <special-string>
+        <special-char> ::= <char> | <whitespace>
+        <char> ::= 'a'
+        ";
+
+        let input = "a or a";
+
+        let passes_1 = fails.replace(
+            // skip nullable production <char_null_two>
+            "<char_null_one> ::= <char_null_two>",
+            "<char_null_one> ::= <char_null_three>",
+        );
+        assert!(passes_1
+            .parse::<Grammar>()
+            .unwrap()
+            .parse_input(input)
+            .next()
+            .is_some());
+
+        let passes_2 = fails.replace(
+            // replace <whitespace> with its terminal ' '
+            "<ws> ::= <whitespace> | ' ' <ws>",
+            "<ws> ::= ' ' | ' ' <ws>",
+        );
+        assert!(passes_2
+            .parse::<Grammar>()
+            .unwrap()
+            .parse_input(input)
+            .next()
+            .is_some());
+
+        let passes_3 = fails.replace(
+            // again, replace <whitespace> with its terminal ' '
+            "<special-char> ::= <char> | <whitespace>",
+            "<special-char> ::= <char> | ' '",
+        );
+        assert!(passes_3
+            .parse::<Grammar>()
+            .unwrap()
+            .parse_input(input)
+            .next()
+            .is_some());
+
+        assert!(
+            fails
+                .parse::<Grammar>()
+                .unwrap()
+                .parse_input(input)
+                .next()
+                .is_some(),
+            "all grammars except last one parsed: {input}"
+        );
+    }
+
+    #[test]
     fn format_parse_tree() {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
         <base> ::= \"A\" | \"C\" | \"G\" | \"T\""

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -2,8 +2,12 @@
 mod defs {
     pub(crate) use tracing::{event, span, Level};
 
+    #[allow(dead_code)]
     pub fn init_subscriber() {
-        tracing_subscriber::fmt::init()
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_ansi(false)
+            .init();
     }
 }
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "tracing")]
 mod defs {
-    pub(crate) use tracing::span;
-    pub(crate) use tracing::Level;
+    pub(crate) use tracing::{event, span, Level};
+
+    pub fn init_subscriber() {
+        tracing_subscriber::fmt::init()
+    }
 }
 
 #[cfg(not(feature = "tracing"))]
@@ -22,6 +25,20 @@ mod defs {
     }
 
     pub(crate) use span;
+
+    pub struct Event {}
+
+    macro_rules! event {
+        ($($any:tt)*) => {{
+            use crate::tracing::Event;
+            Event {}
+        }};
+    }
+
+    pub(crate) use event;
+
+    #[allow(dead_code)]
+    pub fn init_subscriber() {}
 }
 
 pub(crate) use defs::*;


### PR DESCRIPTION
Closes #117 and #118 (hopefully!)

#117 and #118 raised examples of failures to parse input based on grammars. after some investigation, it _seems_ the root cause was shared by both issues.

## Root Cause

Consider the grammar:

```text
<start> ::= <shortfail> | <longsuccess>
<shortfail> ::= <char> 'never'
<char> ::= 'a'
<longsuccess> ::= <long2>
<long2> ::= <long3>
<long3> ::= <long4>
<long4> ::= <char>
```

When parsing input "a", there are two routes: "shortfail" and "longsuccess". As the names suggest, "shortfail" requires fewer traversals, but always fails. "longsuccess" requires more traversal steps, and should eventually succeed.

The issue is caused because both paths predict the non-terminal "char". Practical Earley parsing requires de-duplicating predictions or else recursive grammars fall into infinite loops. The existing Earley implementation in BNF does roughly the following:

(work roughly alternates between the short and long routes because new traversals are appended to the end of the work queue)

```
* <start> ::= • <shortfail>
* <start> ::= • <longsuccess>
* <shortfail> ::= • <char> 'never'
* <longsuccess> ::= • <long2>
* <char> ::= • 'a'
* <long2> ::= • <long3>
* <char> ::= 'a' •
* <long3> ::= • <long4>
* <shortfail> ::= <char> • 'never' // <--- notice this does NOT succeed
* <long4> ::= • <char> // !!! this <char> prediction is IGNORED because an identical prediction was already made
```


All the `<longN>` productions are necessary because otherwise the `<longsuccess>` route is able to predict <char> before its completion.

> I am sorry if I have not explained this super clearly. It is a tricky problem! Funny aside, I actually thought of this bug while developing v0.4.0 . But I (wrongly) assumed there was something about the Earley algorithm which resolved it. I attempted to write a test, but I did not realize it would require so many intermediate non-terminals to expose. Woops!

## Solution

The underlying problem is that because non-terminals can be shared across multiple traversal routes, "completion" must be addressed also during "prediction".

### Performance

On my machine, there was a roughly 10% performance cost to the new parsing logic. I will experiment in the future for improvements, but in the meantime I believe passing tests and correct behavior outweigh the cost.

## Extra

Basically every time I have worked on an Earley bug, I have ended up adding the same manual logging to help with debugging. I decided to commit that logging this time!

There is a new `tracing::event!` which by default is a noop, but with the "tracing" feature enabled adds logging events.

For Earley, traversal state events are logged when created and during predict/scan/complete. It helps quite a bit with debugging!