### PR TITLE
stacker dependency optional (enabled by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ repository = "https://github.com/shnewto/bnf"
 license = "MIT"
 
 [dependencies]
+stacker = { version = "0.1.2", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true }
 tracing-flame = { version = "0.2.0", optional = true }
-
-[dependencies.stacker]
-version = "0.1.2"
 
 [dependencies.rand]
 version = "0.8.0"
@@ -42,7 +40,7 @@ version = "1.0.2"
 criterion = "0.4.0"
 
 [features]
-default = []
+default = ["stacker"]
 unstable = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -273,15 +273,18 @@ impl Grammar {
         f: &impl Fn(&str, &str) -> bool,
     ) -> Result<String, Error> {
         loop {
-            // If we only have 64KB left, we've hit our tolerable threshold for recursion
-            const STACK_RED_ZONE: usize = 64 * 1024;
+            #[cfg(feature = "stacker")]
+            {
+                // If we only have 64KB left, we've hit our tolerable threshold for recursion
+                const STACK_RED_ZONE: usize = 64 * 1024;
 
-            if let Some(remaining) = stacker::remaining_stack() {
-                if remaining < STACK_RED_ZONE {
-                    return Err(Error::RecursionLimit(format!(
-                        "Limit for recursion reached processing <{}>!",
-                        ident
-                    )));
+                if let Some(remaining) = stacker::remaining_stack() {
+                    if remaining < STACK_RED_ZONE {
+                        return Err(Error::RecursionLimit(format!(
+                            "Limit for recursion reached processing <{}>!",
+                            ident
+                        )));
+                    }
                 }
             }
 
@@ -615,6 +618,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "stacker")]
     #[test]
     fn recursion_limit() {
         let grammar: Result<Grammar, _> = "<nonterm> ::= <nonterm>".parse();


### PR DESCRIPTION
The `stacker` crate isn't strictly needed.

We may not wish to use it in production.

Also, its dependency `psm` doesn't support WASM.

It can be made optional (enabled by default).