### PR TITLE
Fix WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ repository = "https://github.com/shnewto/bnf"
 license = "MIT"
 
 [dependencies]
+stacker = { version = "0.1.2", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true }
 tracing-flame = { version = "0.2.0", optional = true }
-
-[dependencies.stacker]
-version = "0.1.2"
 
 [dependencies.rand]
 version = "0.8.0"
@@ -42,7 +40,7 @@ version = "1.0.2"
 criterion = "0.4.0"
 
 [features]
-default = []
+default = ["stacker"]
 unstable = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,9 @@ version = "1.0.61"
 [dev-dependencies.quickcheck]
 version = "1.0.2"
 
-[dev-dependencies]
-criterion = "0.4.0"
+[dev-dependencies.criterion]
+version = "0.4.0"
+default-features = false # to disable Rayon for wasm32
 
 [features]
 default = ["stacker"]
@@ -47,3 +48,6 @@ tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 [[bench]]
 name = "bnf"
 harness = false
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.5", features = ["js"] } # needed for rand

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -273,15 +273,18 @@ impl Grammar {
         f: &impl Fn(&str, &str) -> bool,
     ) -> Result<String, Error> {
         loop {
-            // If we only have 64KB left, we've hit our tolerable threshold for recursion
-            const STACK_RED_ZONE: usize = 64 * 1024;
+            #[cfg(feature = "stacker")]
+            {
+                // If we only have 64KB left, we've hit our tolerable threshold for recursion
+                const STACK_RED_ZONE: usize = 64 * 1024;
 
-            if let Some(remaining) = stacker::remaining_stack() {
-                if remaining < STACK_RED_ZONE {
-                    return Err(Error::RecursionLimit(format!(
-                        "Limit for recursion reached processing <{}>!",
-                        ident
-                    )));
+                if let Some(remaining) = stacker::remaining_stack() {
+                    if remaining < STACK_RED_ZONE {
+                        return Err(Error::RecursionLimit(format!(
+                            "Limit for recursion reached processing <{}>!",
+                            ident
+                        )));
+                    }
                 }
             }
 
@@ -615,6 +618,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "stacker")]
     #[test]
     fn recursion_limit() {
         let grammar: Result<Grammar, _> = "<nonterm> ::= <nonterm>".parse();


### PR DESCRIPTION
Additional fixes on top of https://github.com/shnewto/bnf/pull/121

So we can run:
```
cargo build --no-default-features --target=wasm32-unknown-unknown
```