### PR TITLE
fix arbitrary grammar test seed

### DIFF
--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -13,13 +13,23 @@ struct Meta {
 const BNF_FOR_BNF: &str = std::include_str!("./fixtures/bnf.bnf");
 
 impl Arbitrary for Meta {
-    fn arbitrary(_: &mut Gen) -> Meta {
+    fn arbitrary(gen: &mut Gen) -> Meta {
         // Generate Grammar object from grammar for BNF grammars
         let grammar: Result<Grammar, _> = BNF_FOR_BNF.parse();
         assert!(grammar.is_ok(), "{grammar:?} should be Ok");
 
         // generate a random valid grammar from the above
-        let seed: [u8; 32] = [0; 32];
+        // using an arbitrary seed
+        let seed: [u8; 32] = {
+            let mut seed = [0u8; 32];
+
+            for byte in seed.iter_mut() {
+                *byte = Arbitrary::arbitrary(gen);
+            }
+
+            seed
+        };
+
         let mut rng: StdRng = SeedableRng::from_seed(seed);
         let sentence = grammar.unwrap().generate_seeded(&mut rng);
 


### PR DESCRIPTION
While I was fiddling with some other exploratory improvements, it came up that the generated grammar test was using the same seed for every case. The intention seems to be that the test generates truly arbitrary grammars, so this PR uses the property testing generator to seed the grammar.

TLDR: this property test was using the same grammar for every run. now it doesn't

```txt
// before
Ok(" <F>::= ''  <E> <E>\n")
Ok(" <F>::= ''  <E> <E>\n")
Ok(" <F>::= ''  <E> <E>\n")
Ok(" <F>::= ''  <E> <E>\n")
test test_generated_grammars ... ok

// after
Ok("<NJW> ::=<G> '' <toKJ>     <X> \n")
Ok("<d6> ::= \"''u\" '1|3' \n<G>::=<Mq>  \"\" <a5>   'E' \n <w> ::= <t> |  \"\" \n")
Ok(" <J>::= <t> |   <t>|  <Lu>    |  <t>\"0t\"|<V-A2l><c5><F>'\"' <e>|\"\" \n")
Ok("  <d60> ::=  <d>\n <sw--T>::=<Qu><D> '6d'    |  '='\n<L> ::=  <g> <Q>\"\"'3' \"\"  '\"'\n")
test test_generated_grammars ... ok
```


