### PR TITLE
Prefer single quotes for terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ let input =
         <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
                         | <personal-part> <name-part>
 
-    <personal-part> ::= <initial> \".\" | <first-name>
+    <personal-part> ::= <initial> '.' | <first-name>
 
     <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
 
-        <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>
+        <zip-part> ::= <town-name> ',' <state-code> <ZIP-code> <EOL>
 
-    <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
-        <opt-apt-num> ::= <apt-num> | \"\"";
+    <opt-suffix-part> ::= 'Sr.' | 'Jr.' | <roman-numeral> | ''
+        <opt-apt-num> ::= <apt-num> | ''";
 
 let grammar: Result<Grammar, _> = input.parse();
 match grammar {
@@ -150,7 +150,7 @@ use bnf::Grammar;
 
 let input =
     "<dna> ::= <base> | <base> <dna>
-    <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+    <base> ::= 'A' | 'C' | 'G' | 'T'";
 let grammar: Grammar = input.parse().unwrap();
 let sentence = grammar.generate();
 match sentence {
@@ -165,7 +165,7 @@ use bnf::Grammar;
 
 let input =
     "<dna> ::= <base> | <base> <dna>
-    <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+    <base> ::= 'A' | 'C' | 'G' | 'T'";
 let grammar: Grammar = input.parse().unwrap();
 
 let sentence = "GATTACA";

--- a/benches/bnf.rs
+++ b/benches/bnf.rs
@@ -35,15 +35,17 @@ fn examples(c: &mut Criterion) {
 
     c.bench_function("generate DNA", |b| {
         let input = "<dna> ::= <base> | <base> <dna>
-            <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+            <base> ::= 'A' | 'C' | 'G' | 'T'";
         let grammar: Grammar = input.parse().unwrap();
         b.iter(|| grammar.generate().unwrap());
     });
 
     let polish_calc_grammar: Grammar = "<product> ::= <number> | <op> <product> <product>
-            <op> ::= \"+\" | \"-\" | \"*\" | \"/\"
-            <number> ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\"
-        ".parse().unwrap();
+            <op> ::= '+' | '-' | '*' | '/'
+            <number> ::= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+        "
+    .parse()
+    .unwrap();
 
     // use pseudo random for consistent metrics
     let mut rng: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0);

--- a/src/earley/traversal.rs
+++ b/src/earley/traversal.rs
@@ -255,7 +255,7 @@ mod tests {
 
     fn dna_grammar() -> Grammar {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-            <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+            <base> ::= 'A' | 'C' | 'G' | 'T'"
             .parse()
             .unwrap();
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -333,14 +333,14 @@ mod tests {
 
     #[test]
     fn iterate_terms() {
-        let expression: Expression = "<b> \"a\" <b>".parse().unwrap();
+        let expression: Expression = "<b> 'A' <b>".parse().unwrap();
         let terms = expression.terms_iter().cloned().collect::<Vec<_>>();
         assert_eq!(terms, expression.terms);
     }
 
     #[test]
     fn mutate_iterable_terms() {
-        let mut expression: Expression = "\"END\"".parse().unwrap();
+        let mut expression: Expression = "'END'".parse().unwrap();
         let new_term = Term::Terminal("X".to_string());
         for term in expression.terms_iter_mut() {
             *term = new_term.clone();

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -117,7 +117,7 @@ impl<'gram> ParseTree<'gram> {
     /// ```
     /// # use bnf::Grammar;
     /// let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-    /// <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+    /// <base> ::= 'A' | 'C' | 'G' | 'T'"
     /// .parse()
     /// .unwrap();
     ///
@@ -337,7 +337,7 @@ impl Grammar {
     ///
     /// let input =
     ///     "<dna> ::= <base> | <base> <dna>
-    ///     <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+    ///     <base> ::= 'A' | 'C' | 'G' | 'T'";
     /// let grammar: Grammar = input.parse().unwrap();
     /// let seed: [u8; 32] = [0; 32];
     /// let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -398,7 +398,7 @@ impl Grammar {
     ///
     /// let input =
     ///     "<dna> ::= <base> | <base> <dna>
-    ///     <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+    ///     <base> ::= 'A' | 'C' | 'G' | 'T'";
     /// let grammar: Grammar = input.parse().unwrap();
     /// let sentence = grammar.generate();
     /// # let sentence_clone = sentence.clone();
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn format_grammar() {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
             .parse()
             .unwrap();
         let format = format!("{grammar}");
@@ -695,7 +695,7 @@ mod tests {
     #[test]
     fn iterate_parse_tree() {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
             .parse()
             .unwrap();
 
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     fn iterate_mut_parse_tree() {
         let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
             .parse()
             .unwrap();
 

--- a/src/production.rs
+++ b/src/production.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn parse_error() {
-        let result = Production::from_str("<base> ::= \"A\" | \"C\" | \"G\" |");
+        let result = Production::from_str("<base> ::= 'A' | 'C' | 'G' |");
         assert!(
             result.is_err(),
             "production result should be error {result:?}"
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn parse_semicolon_separated() {
-        let result = Production::from_str("<base> ::= \"A\" ; \"C\" ; \"G\" ; \"T\"");
+        let result = Production::from_str("<base> ::= 'A' ; 'C' ; 'G' ; 'T'");
         assert!(result.is_err(), "{result:?} should be error");
 
         let production = result.unwrap_err();

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -10,29 +10,29 @@ mod std_trait {
 
     #[test]
     fn expression_from_str() {
-        let input = "\"😵\" \"😋\" \"😉\"";
+        let input = "'😵' '😋' '😉'";
         let expression = Expression::new();
         std_str_trait(expression, input)
     }
 
     #[test]
     fn grammar_from_str() {
-        let input = "<🙃> ::= \"😵\" \"😋\" | \"😉\"
-        <🤘> ::= \"👏 \" \"👊\" | \"👌\"";
+        let input = "<🙃> ::= '😵' '😋' | '😉'
+        <🤘> ::= '👏 ' '👊' | '👌'";
         let grammar = Grammar::new();
         std_str_trait(grammar, input)
     }
 
     #[test]
     fn production_from_str() {
-        let input = "<🤘> ::= \"👏 \" \"👊\" | \"👌\"";
+        let input = "<🤘> ::= '👏 ' '👊' | '👌'";
         let production = Production::new();
         std_str_trait(production, input)
     }
 
     #[test]
     fn terminal_from_str() {
-        let input = "\"👏 \"";
+        let input = "'👏 '";
         let terminal = Term::Terminal(String::new());
         std_str_trait(terminal, input)
     }
@@ -50,29 +50,29 @@ mod custom_trait {
 
     #[test]
     fn expression_from_str() {
-        let input = "\"😵\" \"😋\" \"😉\"";
+        let input = "'😵' '😋' '😉'";
         let expression: Result<Expression, _> = input.parse();
         assert!(expression.is_ok())
     }
 
     #[test]
     fn grammar_from_str() {
-        let input = "<🙃> ::= \"😵\" \"😋\" | \"😉\"
-        <🤘> ::= \"👏 \" \"👊\" | \"👌\"";
+        let input = "<🙃> ::= '😵' '😋' | '😉'
+        <🤘> ::= '👏 ' '👊' | '👌'";
         let grammar: Result<Grammar, _> = input.parse();
         assert!(grammar.is_ok())
     }
 
     #[test]
     fn production_from_str() {
-        let input = "<🤘> ::= \"👏 \" \"👊\" | \"👌\"";
+        let input = "<🤘> ::= '👏 ' '👊' | '👌'";
         let production: Result<Production, _> = input.parse();
         assert!(production.is_ok())
     }
 
     #[test]
     fn terminal_from_str() {
-        let input = "\"👏 \"";
+        let input = "'👏 '";
         let terminal: Result<Term, _> = input.parse();
         assert!(terminal.is_ok())
     }

--- a/tests/iterate.rs
+++ b/tests/iterate.rs
@@ -4,7 +4,7 @@ use bnf::{Grammar, Term};
 fn iterate_grammar() {
     let dna_productions = "
         <dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+        <base> ::= 'A' | 'C' | 'G' | 'T'";
 
     let dna_grammar: Grammar = dna_productions.parse().unwrap();
 
@@ -62,7 +62,7 @@ fn iterate_grammar() {
 fn mutably_iterate_grammar() {
     let dna_productions = "
         <dna> ::= <dna> | <base> <dna>;
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\";";
+        <base> ::= 'A' | 'C' | 'G' | 'T';";
 
     let mut dna_grammar: Grammar = dna_productions.parse().unwrap();
 

--- a/tests/parse_input.rs
+++ b/tests/parse_input.rs
@@ -19,7 +19,7 @@ fn undefined_prod() {
 #[test]
 fn dna_left_recursive() {
     let grammar: Grammar = "<dna> ::= <base> | <dna> <base>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
         .parse()
         .unwrap();
 
@@ -32,7 +32,7 @@ fn dna_left_recursive() {
 #[test]
 fn dna_right_recursive() {
     let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
         .parse()
         .unwrap();
 
@@ -45,8 +45,8 @@ fn dna_right_recursive() {
 #[test]
 fn ambiguous() {
     let grammar: Grammar = "<start> ::= <a> | <b>
-        <a> ::= \"END\"
-        <b> ::= \"END\""
+        <a> ::= 'END'
+        <b> ::= 'END'"
         .parse()
         .unwrap();
 
@@ -100,8 +100,8 @@ fn empty_left_recursive() {
 
 #[test]
 fn complete_empty() {
-    let grammar: Grammar = "<start> ::= \"hi\" <empty>
-        <empty> ::= \"\""
+    let grammar: Grammar = "<start> ::= 'hi' <empty>
+        <empty> ::= ''"
         .parse()
         .unwrap();
 
@@ -113,7 +113,7 @@ fn complete_empty() {
 
 #[test]
 fn empty() {
-    let grammar: Grammar = "<start> ::= \"\"".parse().unwrap();
+    let grammar: Grammar = "<start> ::= ''".parse().unwrap();
 
     let input = "";
 
@@ -296,14 +296,16 @@ fn math() {
             <sum> ::= <product>
             <product> ::= <product> <mult> <factor>
             <product> ::= <factor>
-            <add> ::= \"+\" | \"-\"
-            <mult> ::= \"*\" | \"/\"
-            <factor> ::= \"(\" <sum> \")\"
+            <add> ::= '+' | '-'
+            <mult> ::= '*' | '/'
+            <factor> ::= '(' <sum> ')'
             <factor> ::= <number>
             <number> ::= <digit> <number>
             <number> ::= <digit>
-            <digit> ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\"
-        ".parse().unwrap();
+            <digit> ::= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+        "
+    .parse()
+    .unwrap();
 
     let input = "1+(2*3-4)";
 
@@ -314,7 +316,7 @@ fn math() {
 #[test]
 fn parse_dna() {
     let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
         .parse()
         .unwrap();
 
@@ -441,7 +443,7 @@ fn branching_and_overlapping_parse_trees() {
 #[test]
 fn format_parse_tree() {
     let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
         .parse()
         .unwrap();
 
@@ -453,7 +455,7 @@ fn format_parse_tree() {
 #[test]
 fn mermaid_dna_parse_tree() {
     let grammar: Grammar = "<dna> ::= <base> | <base> <dna>
-        <base> ::= \"A\" | \"C\" | \"G\" | \"T\""
+        <base> ::= 'A' | 'C' | 'G' | 'T'"
         .parse()
         .unwrap();
 
@@ -472,14 +474,16 @@ fn mermaid_math_parse_tree() {
             <sum> ::= <product>
             <product> ::= <product> <mult> <factor>
             <product> ::= <factor>
-            <add> ::= \"+\" | \"-\"
-            <mult> ::= \"*\" | \"/\"
-            <factor> ::= \"(\" <sum> \")\"
+            <add> ::= '+' | '-'
+            <mult> ::= '*' | '/'
+            <factor> ::= '(' <sum> ')'
             <factor> ::= <number>
             <number> ::= <digit> <number>
             <number> ::= <digit>
-            <digit> ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\"
-        ".parse().unwrap();
+            <digit> ::= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+        "
+    .parse()
+    .unwrap();
 
     let input = "1+(2*3-4)";
 


### PR DESCRIPTION
An even more silly PR, but maybe a style question. Most of BNF's examples and tests use double quotes for the string literal of terminals. This leads to a lot of escaping, and takes more space than a single quote (`\"` vs `'`).

This PR changes examples and tests to use single quotes. I don't think this matters much, but it does look better to my arbitrary eyes/brain.

The one controversial part to his that I see is that the existing `Display` implementations default to double quotes. So users who call `Grammar.to_string()` or similar will see the terminals in double quotes.

An alternative to this PR would be to update examples / tests to use `r#` string literals. This would allow for double quotes, without the need to escape:

`r#"<zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>"#`