### PR TITLE
Reworked generate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "bnf"
 version = "0.4.4"
 edition = "2021"
-authors = ["@shnewto", "@CrockAgile", "@androm3da", "@sremedios", "@prbs23", "@z2oh",
-"@lionel1704", "@benarmstead", "@jonay2000", "@SKalt", "@DrunkJon", "@Axiomatic-Mind"]
+authors = ["@shnewto", "@CrockAgile"]
 
 description = "A library for parsing Backus–Naur form context-free grammars"
 readme = "README.md"
@@ -16,7 +15,6 @@ repository = "https://github.com/shnewto/bnf"
 license = "MIT"
 
 [dependencies]
-stacker = { version = "0.1.2", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }
 tracing-flame = { version = "0.2.0", optional = true }
@@ -45,7 +43,7 @@ version = "0.4.0"
 default-features = false # to disable Rayon for wasm32
 
 [features]
-default = ["stacker"]
+default = []
 unstable = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnf"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["@shnewto", "@CrockAgile"]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,15 +11,12 @@ use nom::{
 pub enum Error {
     ParseError(String),
     GenerateError(String),
-    RecursionLimit(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::ParseError(ref s)
-            | Error::GenerateError(ref s)
-            | Error::RecursionLimit(ref s) => write!(f, "{s}"),
+            Error::ParseError(ref s) | Error::GenerateError(ref s) => write!(f, "{s}"),
         }
     }
 }
@@ -106,15 +103,6 @@ mod tests {
     }
 
     #[test]
-    fn uses_error_recursion_limit() {
-        let bnf_error = Error::RecursionLimit(String::from("reucrsion limit reached!"));
-        match bnf_error {
-            Error::RecursionLimit(_) => (),
-            e => panic!("should match on reursion limit: {e:?}"),
-        }
-    }
-
-    #[test]
     fn uses_error_generate() {
         let bnf_error = Error::GenerateError(String::from("error generating!"));
         match bnf_error {
@@ -127,16 +115,11 @@ mod tests {
     fn test_error_display() {
         let parse_error = Error::ParseError(String::from("parsing error!"));
         let generate_error = Error::GenerateError(String::from("error generating!"));
-        let recursion_error = Error::RecursionLimit(String::from("recursion limit reached!"));
 
         assert_eq!(parse_error.to_string(), String::from("parsing error!"));
         assert_eq!(
             generate_error.to_string(),
             String::from("error generating!")
-        );
-        assert_eq!(
-            recursion_error.to_string(),
-            String::from("recursion limit reached!")
         );
     }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -379,94 +379,76 @@ mod tests {
         let mut expression: Expression;
 
         expression = "<a> <b> <c>".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "'a' <b> <c>".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "<a> 'b' <c>".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "<a> <b> 'c'".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "'a' 'b' <c>".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "'a' <b> 'c'".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "<a> 'b' 'c'".parse().unwrap();
-        assert_eq!(expression.terminates(None), false);
+        assert!(!expression.terminates(None));
 
         expression = "'a' <b> <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![
-                Term::from_str("<b>").unwrap(),
-                Term::from_str("<1>").unwrap(),
-                Term::from_str("<2>").unwrap(),
-            ])),
-            false
-        );
+        assert!(!expression.terminates(Some(&vec![
+            Term::from_str("<b>").unwrap(),
+            Term::from_str("<1>").unwrap(),
+            Term::from_str("<2>").unwrap(),
+        ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![
-                Term::from_str("<c>").unwrap(),
-                Term::from_str("<b>").unwrap(),
-                Term::from_str("<1>").unwrap(),
-            ])),
-            false
-        );
+        assert!(!expression.terminates(Some(&vec![
+            Term::from_str("<c>").unwrap(),
+            Term::from_str("<b>").unwrap(),
+            Term::from_str("<1>").unwrap(),
+        ])));
     }
 
     #[test]
     fn does_terminate() {
         let mut expression: Expression = "'a' 'b' 'c'".parse().unwrap();
-        assert_eq!(expression.terminates(None), true);
+        assert!(expression.terminates(None));
 
         expression = "'a' 'b'".parse().unwrap();
-        assert_eq!(expression.terminates(None), true);
+        assert!(expression.terminates(None));
 
         expression = "'a'".parse().unwrap();
-        assert_eq!(expression.terminates(None), true);
+        assert!(expression.terminates(None));
 
         let mut expression: Expression = "'a' 'b' <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![Term::from_str("<c>").unwrap()])),
-            true
-        );
+        assert!(expression.terminates(Some(&vec![Term::from_str("<c>").unwrap()])));
 
         expression = "'a' <b> <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![
-                Term::from_str("<c>").unwrap(),
-                Term::from_str("<b>").unwrap(),
-            ])),
-            true
-        );
+        assert!(expression.terminates(Some(&vec![
+            Term::from_str("<c>").unwrap(),
+            Term::from_str("<b>").unwrap(),
+        ])));
 
         expression = "'a' <b> <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![
-                Term::from_str("<c>").unwrap(),
-                Term::from_str("<b>").unwrap(),
-                Term::from_str("<1>").unwrap(),
-                Term::from_str("<2>").unwrap(),
-            ])),
-            true
-        );
+        assert!(expression.terminates(Some(&vec![
+            Term::from_str("<c>").unwrap(),
+            Term::from_str("<b>").unwrap(),
+            Term::from_str("<1>").unwrap(),
+            Term::from_str("<2>").unwrap(),
+        ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
-        assert_eq!(
-            expression.terminates(Some(&vec![
-                Term::from_str("<c>").unwrap(),
-                Term::from_str("<b>").unwrap(),
-                Term::from_str("<1>").unwrap(),
-                Term::from_str("<2>").unwrap(),
-                Term::from_str("<a>").unwrap(),
-            ],)),
-            true
-        );
+        assert!(expression.terminates(Some(&vec![
+            Term::from_str("<c>").unwrap(),
+            Term::from_str("<b>").unwrap(),
+            Term::from_str("<1>").unwrap(),
+            Term::from_str("<2>").unwrap(),
+            Term::from_str("<a>").unwrap(),
+        ],)));
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -84,7 +84,7 @@ impl Expression {
             .filter(|t| matches!(t, Term::Nonterminal(_)));
 
         for nt in nonterms {
-            if !terminating_rules.iter().any(|r| *r == nt) {
+            if !terminating_rules.contains(&nt) {
                 return false;
             }
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -70,7 +70,7 @@ impl Expression {
 
     /// Determine if this expression terminates or not, i.e contains all terminal elements or every
     /// non-terminal element in the expression exists in the (optional) list of 'terminating rules'
-    pub fn terminates(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn terminates(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
         if !self.terms.iter().any(|t| matches!(t, Term::Nonterminal(_))) {
             return true;
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -75,18 +75,16 @@ impl Expression {
             return true;
         }
 
-        if terminating_rules.is_none() {
+        let Some(terminating_rules) = terminating_rules else {
             return false;
-        }
+        };
 
-        let nonterms: Vec<Term> = self
-            .terms
-            .clone()
-            .into_iter()
-            .filter(|t| matches!(t, Term::Nonterminal(_)))
-            .collect();
+        let nonterms = self
+            .terms_iter()
+            .filter(|t| matches!(t, Term::Nonterminal(_)));
+
         for nt in nonterms {
-            if !terminating_rules.unwrap().iter().any(|r| *r == nt) {
+            if !terminating_rules.iter().any(|r| r == nt) {
                 return false;
             }
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -70,7 +70,7 @@ impl Expression {
 
     /// Determine if this expression terminates or not, i.e contains all terminal elements or every
     /// non-terminal element in the expression exists in the (optional) list of 'terminating rules'
-    pub(crate) fn terminates(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn terminates(&self, terminating_rules: Option<&Vec<&Term>>) -> bool {
         if !self.terms.iter().any(|t| matches!(t, Term::Nonterminal(_))) {
             return true;
         }
@@ -84,7 +84,7 @@ impl Expression {
             .filter(|t| matches!(t, Term::Nonterminal(_)));
 
         for nt in nonterms {
-            if !terminating_rules.iter().any(|r| r == nt) {
+            if !terminating_rules.iter().any(|r| *r == nt) {
                 return false;
             }
         }
@@ -399,16 +399,16 @@ mod tests {
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(!expression.terminates(Some(&vec![
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
         ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
         assert!(!expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
         ])));
     }
 
@@ -424,29 +424,29 @@ mod tests {
         assert!(expression.terminates(None));
 
         let mut expression: Expression = "'a' 'b' <c>".parse().unwrap();
-        assert!(expression.terminates(Some(&vec![Term::from_str("<c>").unwrap()])));
+        assert!(expression.terminates(Some(&vec![&Term::from_str("<c>").unwrap()])));
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
         ])));
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
         ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
-            Term::from_str("<a>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
+            &Term::from_str("<a>").unwrap(),
         ],)));
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -422,9 +422,12 @@ impl Grammar {
         self.generate_seeded_callback(&mut rng, f)
     }
 
-    pub fn terminates(&self) -> bool {
+    /// Determine if the starting rule of the grammar can take us to a terminal state, i.e. all
+    /// Term::Terminal types. Used as a check before generation, to tell if we can safely attempt
+    /// to generate sentences without risking infinite loops
+    pub(crate) fn terminates(&self) -> bool {
         if self.starting_term().is_none() {
-            // if there are no rules, there's nothing to do so... it does terminate.
+            // if there are no rules, there's nothing to do so... it terminates
             return true;
         }
 
@@ -454,6 +457,7 @@ impl Grammar {
         terminating_rules.into_iter().any(|t| t == *starting_term)
     }
 
+    /// collect Production LHSs that can get us to a terminating state, i.e. all Term::Terminals
     fn collect_terminating_rules(&self, terminating_rules: &Vec<Term>) -> Vec<Term> {
         let mut res: Vec<Term> = terminating_rules.clone();
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -750,7 +750,7 @@ mod tests {
         let mut grammar: Grammar;
 
         grammar = "<nonterm> ::= <nonterm>".parse().unwrap();
-        assert_eq!(grammar.terminates(), false);
+        assert!(!grammar.terminates());
 
         grammar = "
         <A> ::= <X> | <A> <X>
@@ -759,7 +759,7 @@ mod tests {
         <Z> ::= 'terminating state!'"
             .parse()
             .unwrap();
-        assert_eq!(grammar.terminates(), false);
+        assert!(!grammar.terminates());
 
         grammar = "
         <not-a-good-first-state-lhs> ::= <not-a-good-first-state-rhs>
@@ -769,14 +769,14 @@ mod tests {
         <Z> ::= 'terminating state!'"
             .parse()
             .unwrap();
-        assert_eq!(grammar.terminates(), false);
+        assert!(!grammar.terminates());
     }
 
     #[test]
     fn does_terminate() {
         let mut grammar: Grammar;
         grammar = "<nonterm> ::= 'term'".parse().unwrap();
-        assert_eq!(grammar.terminates(), true);
+        assert!(grammar.terminates());
 
         grammar = "
         <A> ::= <B> | <A> <B>
@@ -807,6 +807,6 @@ mod tests {
         <Z> ::= 'terminating state!'"
             .parse()
             .unwrap();
-        assert_eq!(grammar.terminates(), true);
+        assert!(grammar.terminates());
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -450,7 +450,7 @@ impl Grammar {
             is_progress = false;
 
             for prod in self.productions_iter() {
-                let marked = terminating_rules.iter().any(|r| *r == &prod.lhs);
+                let marked = terminating_rules.contains(&&prod.lhs);
 
                 // if already marked, then no need to reprocess
                 if marked {

--- a/src/production.rs
+++ b/src/production.rs
@@ -316,91 +316,76 @@ mod tests {
     #[test]
     fn does_have_terminating_expression() {
         let mut production: Production = "<S> ::= 'T'".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), true);
+        assert!(production.has_terminating_expression(None));
 
         production = "<S> ::= 'T' | <NT>".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), true);
+        assert!(production.has_terminating_expression(None));
 
         production = "<S> ::= <NT> | 'T'".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), true);
+        assert!(production.has_terminating_expression(None));
 
         production = "<S> ::= <NT1> | 'T' | <NT2>".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), true);
+        assert!(production.has_terminating_expression(None));
 
         production = "<S> ::= 'T1' | <NT> | 'T2'".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), true);
+        assert!(production.has_terminating_expression(None));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
-        assert_eq!(
-            production.has_terminating_expression(Some(&vec![
-                Term::from_str("<NT1>").unwrap(),
-                Term::from_str("<NT2>").unwrap(),
-                Term::from_str("<NTa>").unwrap(),
-                Term::from_str("<NTb>").unwrap(),
-            ])),
-            true
-        );
+        assert!(production.has_terminating_expression(Some(&vec![
+            Term::from_str("<NT1>").unwrap(),
+            Term::from_str("<NT2>").unwrap(),
+            Term::from_str("<NTa>").unwrap(),
+            Term::from_str("<NTb>").unwrap(),
+        ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
-        assert_eq!(
-            production.has_terminating_expression(Some(&vec![
-                Term::from_str("<NTa>").unwrap(),
-                Term::from_str("<NT4>").unwrap(),
-                Term::from_str("<NTc>").unwrap(),
-                Term::from_str("<NTb>").unwrap(),
-            ])),
-            true
-        );
+        assert!(production.has_terminating_expression(Some(&vec![
+            Term::from_str("<NTa>").unwrap(),
+            Term::from_str("<NT4>").unwrap(),
+            Term::from_str("<NTc>").unwrap(),
+            Term::from_str("<NTb>").unwrap(),
+        ])));
     }
 
     #[test]
     fn does_not_have_terminating_expression() {
         let mut production: Production = "<S> ::= <NT>".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), false);
+        assert!(!production.has_terminating_expression(None));
 
         production = "<S> ::= 'T' <NT>".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), false);
+        assert!(!production.has_terminating_expression(None));
 
         production = "<S> ::= <NT> 'T'".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), false);
+        assert!(!production.has_terminating_expression(None));
 
         production = "<S> ::= <NT1> 'T' | <NT2>".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), false);
+        assert!(!production.has_terminating_expression(None));
 
         production = "<S> ::= <NT1> | <NT> 'T2'".parse().unwrap();
-        assert_eq!(production.has_terminating_expression(None), false);
+        assert!(!production.has_terminating_expression(None));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
-        assert_eq!(
-            production.has_terminating_expression(Some(&vec![
-                Term::from_str("<NT1>").unwrap(),
-                Term::from_str("<NTa>").unwrap(),
-                Term::from_str("<NTb>").unwrap(),
-                Term::from_str("<NTc>").unwrap(),
-            ])),
-            false
-        );
+        assert!(!production.has_terminating_expression(Some(&vec![
+            Term::from_str("<NT1>").unwrap(),
+            Term::from_str("<NTa>").unwrap(),
+            Term::from_str("<NTb>").unwrap(),
+            Term::from_str("<NTc>").unwrap(),
+        ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
-        assert_eq!(
-            production.has_terminating_expression(Some(&vec![
-                Term::from_str("<NT2>").unwrap(),
-                Term::from_str("<NTa>").unwrap(),
-                Term::from_str("<NTb>").unwrap(),
-                Term::from_str("<NTc>").unwrap(),
-            ])),
-            false
-        );
+        assert!(!production.has_terminating_expression(Some(&vec![
+            Term::from_str("<NT2>").unwrap(),
+            Term::from_str("<NTa>").unwrap(),
+            Term::from_str("<NTb>").unwrap(),
+            Term::from_str("<NTc>").unwrap(),
+        ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
-        assert_eq!(
-            production.has_terminating_expression(Some(&vec![
-                Term::from_str("<NTa>").unwrap(),
-                Term::from_str("<NTb>").unwrap(),
-                Term::from_str("<NTc>").unwrap(),
-                Term::from_str("<NTd>").unwrap(),
-            ])),
-            false
-        );
+        assert!(!production.has_terminating_expression(Some(&vec![
+            Term::from_str("<NTa>").unwrap(),
+            Term::from_str("<NTb>").unwrap(),
+            Term::from_str("<NTc>").unwrap(),
+            Term::from_str("<NTd>").unwrap(),
+        ])));
     }
 }

--- a/src/production.rs
+++ b/src/production.rs
@@ -72,7 +72,7 @@ impl Production {
     /// If the production _can_ terminate,
     /// i.e. contains an expression of all terminals or every non-terminal in an
     /// expression exists in the (optional) list of 'terminating rules'
-    pub fn has_terminating_expression(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn has_terminating_expression(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
         self.rhs.iter().any(|e| e.terminates(terminating_rules))
     }
 }

--- a/src/production.rs
+++ b/src/production.rs
@@ -72,7 +72,10 @@ impl Production {
     /// If the production _can_ terminate,
     /// i.e. contains an expression of all terminals or every non-terminal in an
     /// expression exists in the (optional) list of 'terminating rules'
-    pub(crate) fn has_terminating_expression(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn has_terminating_expression(
+        &self,
+        terminating_rules: Option<&Vec<&Term>>,
+    ) -> bool {
         self.rhs.iter().any(|e| e.terminates(terminating_rules))
     }
 }
@@ -332,18 +335,18 @@ mod tests {
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT1>").unwrap(),
-            Term::from_str("<NT2>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NT1>").unwrap(),
+            &Term::from_str("<NT2>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NT4>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NT4>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
         ])));
     }
 
@@ -366,26 +369,26 @@ mod tests {
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT1>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NT1>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT2>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NT2>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
-            Term::from_str("<NTd>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NTd>").unwrap(),
         ])));
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -9,7 +9,7 @@ use std::ops;
 use std::str::FromStr;
 
 /// A Term can represent a Terminal or Nonterminal node
-#[derive(Deserialize, Serialize, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum Term {
     /// A term which cannot be expanded further via productions
     Terminal(String),

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -1,4 +1,3 @@
-use bnf::Error;
 use bnf::Grammar;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
@@ -35,16 +34,7 @@ impl Arbitrary for Meta {
 
         match sentence {
             Err(e) => {
-                match e {
-                    // shouldn't cause parsing to fail if random generation
-                    // recurses too far
-                    Error::RecursionLimit(_) => Meta {
-                        bnf: String::from(
-                            "<if-recursion-limit-reached> ::= \"parse shouldn't fail\"",
-                        ),
-                    },
-                    _ => panic!("Unexpected state {e:?} -- seed {seed:?}"),
-                }
+                panic!("Unexpected state {e:?} -- seed {seed:?}")
             }
             Ok(s) => Meta { bnf: s },
         }


### PR DESCRIPTION
## Implementation

A swing at addressing #70 though rather than getting any smarter about how we actually generate sentences (that can surely be improved someday), the changes in this PR implement checks that generation _can_ succeed. Aside from the tests, and a couple little things `cargo fmt` threw in there, the actual implementation is relatively short, thanks to the proposal from @notDhruv, that served me well ❤️ 

That proposal was for implementation that effectively lets us decide if generation can succeed lives here https://github.com/shnewto/bnf/issues/70#issuecomment-1356299131

I was happy to follow it to the letter, though one note if you're looking at the code, in my implementation "marking" non-terminals means adding them to a `Vec` called `terminating_rules`

## Heads Up

This represents a breaking change! (though a great one imo) It removes the `RecursionLimit` error, and previously, you could generate from grammars that didn't hit a terminal state, they'd just print what they had, including the string representation of non-terminals if that's all there was. Now, that's not the case :) 

 
