### PR TITLE
Reworked generate perf

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -84,7 +84,7 @@ impl Expression {
             .filter(|t| matches!(t, Term::Nonterminal(_)));
 
         for nt in nonterms {
-            if !terminating_rules.iter().any(|r| *r == nt) {
+            if !terminating_rules.contains(&nt) {
                 return false;
             }
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -75,18 +75,16 @@ impl Expression {
             return true;
         }
 
-        if terminating_rules.is_none() {
+        let Some(terminating_rules) = terminating_rules else {
             return false;
-        }
+        };
 
-        let nonterms: Vec<Term> = self
-            .terms
-            .clone()
-            .into_iter()
-            .filter(|t| matches!(t, Term::Nonterminal(_)))
-            .collect();
+        let nonterms = self
+            .terms_iter()
+            .filter(|t| matches!(t, Term::Nonterminal(_)));
+
         for nt in nonterms {
-            if !terminating_rules.unwrap().iter().any(|r| *r == nt) {
+            if !terminating_rules.iter().any(|r| r == nt) {
                 return false;
             }
         }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -70,7 +70,7 @@ impl Expression {
 
     /// Determine if this expression terminates or not, i.e contains all terminal elements or every
     /// non-terminal element in the expression exists in the (optional) list of 'terminating rules'
-    pub(crate) fn terminates(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn terminates(&self, terminating_rules: Option<&Vec<&Term>>) -> bool {
         if !self.terms.iter().any(|t| matches!(t, Term::Nonterminal(_))) {
             return true;
         }
@@ -84,7 +84,7 @@ impl Expression {
             .filter(|t| matches!(t, Term::Nonterminal(_)));
 
         for nt in nonterms {
-            if !terminating_rules.iter().any(|r| r == nt) {
+            if !terminating_rules.iter().any(|r| *r == nt) {
                 return false;
             }
         }
@@ -399,16 +399,16 @@ mod tests {
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(!expression.terminates(Some(&vec![
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
         ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
         assert!(!expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
         ])));
     }
 
@@ -424,29 +424,29 @@ mod tests {
         assert!(expression.terminates(None));
 
         let mut expression: Expression = "'a' 'b' <c>".parse().unwrap();
-        assert!(expression.terminates(Some(&vec![Term::from_str("<c>").unwrap()])));
+        assert!(expression.terminates(Some(&vec![&Term::from_str("<c>").unwrap()])));
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
         ])));
 
         expression = "'a' <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
         ])));
 
         expression = "<a> <b> <c>".parse().unwrap();
         assert!(expression.terminates(Some(&vec![
-            Term::from_str("<c>").unwrap(),
-            Term::from_str("<b>").unwrap(),
-            Term::from_str("<1>").unwrap(),
-            Term::from_str("<2>").unwrap(),
-            Term::from_str("<a>").unwrap(),
+            &Term::from_str("<c>").unwrap(),
+            &Term::from_str("<b>").unwrap(),
+            &Term::from_str("<1>").unwrap(),
+            &Term::from_str("<2>").unwrap(),
+            &Term::from_str("<a>").unwrap(),
         ],)));
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -450,7 +450,7 @@ impl Grammar {
             is_progress = false;
 
             for prod in self.productions_iter() {
-                let marked = terminating_rules.iter().any(|r| *r == &prod.lhs);
+                let marked = terminating_rules.contains(&&prod.lhs);
 
                 // if already marked, then no need to reprocess
                 if marked {

--- a/src/production.rs
+++ b/src/production.rs
@@ -72,7 +72,10 @@ impl Production {
     /// If the production _can_ terminate,
     /// i.e. contains an expression of all terminals or every non-terminal in an
     /// expression exists in the (optional) list of 'terminating rules'
-    pub(crate) fn has_terminating_expression(&self, terminating_rules: Option<&Vec<Term>>) -> bool {
+    pub(crate) fn has_terminating_expression(
+        &self,
+        terminating_rules: Option<&Vec<&Term>>,
+    ) -> bool {
         self.rhs.iter().any(|e| e.terminates(terminating_rules))
     }
 }
@@ -332,18 +335,18 @@ mod tests {
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT1>").unwrap(),
-            Term::from_str("<NT2>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NT1>").unwrap(),
+            &Term::from_str("<NT2>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NT4>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NT4>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
         ])));
     }
 
@@ -366,26 +369,26 @@ mod tests {
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT1>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NT1>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NT2>").unwrap(),
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NT2>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
         ])));
 
         production = "<S> ::= <NT1> <NT2> | <NT3> | <NT4>".parse().unwrap();
         assert!(!production.has_terminating_expression(Some(&vec![
-            Term::from_str("<NTa>").unwrap(),
-            Term::from_str("<NTb>").unwrap(),
-            Term::from_str("<NTc>").unwrap(),
-            Term::from_str("<NTd>").unwrap(),
+            &Term::from_str("<NTa>").unwrap(),
+            &Term::from_str("<NTb>").unwrap(),
+            &Term::from_str("<NTc>").unwrap(),
+            &Term::from_str("<NTd>").unwrap(),
         ])));
     }
 }


### PR DESCRIPTION
The new `Grammar::generate` logic made sense. But benchmarking on my local machine showed ~55% performance impact (likely the recursive allocation of vectors). With a little refactoring, my local perf got back within *noise* of the performance on `main` branch.