### PR TITLE
LLVM coverage reporting

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,9 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-filter: covered
-output-type: lcov
-output-path: ./lcov.info
-prefix-dir: /home/user/build/
-ignore:
-  - "../*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,24 +95,18 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      - id: coverage
-        uses: actions-rs/grcov@v0.1
-        with:
-          config: configs/grcov.yml      
+      - name: install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+      - name: cargo install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: cargo llvm-cov
+        run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Coveralls upload
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
-  
+          path-to-lcov: lcov.info
+
   clippy:
     needs: [format]
     runs-on: ubuntu-latest


### PR DESCRIPTION
I saw a repo the other day using LLVM to inject coverage reporting. I thought I would give it a try since `grcov` having issues.