### PR TITLE
New release process (release with a manually triggered action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo llvm-cov
-        run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
       - name: Coveralls upload
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/tag-and-publish-crate.yaml
+++ b/.github/workflows/tag-and-publish-crate.yaml
@@ -1,0 +1,47 @@
+name: tag and publish crate [manual]
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-increment:
+        default: patch
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: install rustfmt
+        run: rustup component add rustfmt
+      - name: rustfmt check
+        run: cargo fmt --all -- --check
+      - name: install clippy
+        run: rustup component add clippy
+      - name: cargo clippy
+        run: cargo clippy --all-features --all-targets
+      - name: cargo test
+        run: cargo test
+      - name: install cargo bump
+        run: cargo install cargo-bump
+      - name: bump version
+        run: cargo bump -g ${{ inputs.tag-increment }}
+      - name: push
+        run: git push && git push --tags
+      - name: cargo publish
+        run: cargo publish --token ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bnf"
+# don't manually edit this version unless you're sure you want to circumvent the process documented in RELEASE.md
 version = "0.5.0"
 edition = "2021"
 authors = ["@shnewto", "@CrockAgile"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
   - once the action completes, the Cargo.toml will be updated and the crate will be live on crates.io
 - create a release (with title, notes, thanks, etc) and tie it to the tag that was created by the action / new crate version
 
-## Troubleshooting
+## Execution
 
 The order of operations for tagging and publishing in the action is this
 
@@ -14,7 +14,9 @@ The order of operations for tagging and publishing in the action is this
 1. push the new tag to the repo
 1. publish the new version to crates.io
 
-- if step 1 fails, after addressing the error, you run the action again
-- if step 2 fails, after addressing the error, you run the action again
-- if step 3 fails (the Cargo.toml version was incremented), after addressing the error, you should manually tag (github's ux or the cli) and manually publish the crate with `cargo publish`
-- if step 4 fails (the Cargo.toml version was incremented and there's a new corresponding tag), after addressing the error, you should manually publish the crate  with `cargo publish`
+## Troubleshooting
+
+- if step 1 of execution fails, after addressing the error, you run the action again
+- if step 2 of execution fails, after addressing the error, you run the action again
+- if step 3 of execution fails (the Cargo.toml version was incremented), after addressing the error, you should manually tag (github's ux or the cli) and manually publish the crate with `cargo publish`
+- if step 4 of execution fails (the Cargo.toml version was incremented and there's a new corresponding tag), after addressing the error, you should manually publish the crate  with `cargo publish`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,20 @@
+# Release Process
+
+- leave the Cargo.toml package version alone :)
+- trigger the `tag and publish crate [manual]` action and specify the release increment (major, minor, or patch)
+  - once the action completes, the Cargo.toml will be updated and the crate will be live on crates.io
+- create a release (with title, notes, thanks, etc) and tie it to the tag that was created by the action / new crate version
+
+## Troubleshooting
+
+The order of operations for tagging and publishing in the action is this
+
+1. run all checks, i.e. fmt, clippy, tests, etc
+1. push change / update to the Cargo.toml
+1. push the new tag to the repo
+1. publish the new version to crates.io
+
+- if step 1 fails, after addressing the error, you run the action again
+- if step 2 fails, after addressing the error, you run the action again
+- if step 3 fails (the Cargo.toml version was incremented), after addressing the error, you should manually tag (github's ux or the cli) and manually publish the crate with `cargo publish`
+- if step 4 fails (the Cargo.toml version was incremented and there's a new corresponding tag), after addressing the error, you should manually publish the crate  with `cargo publish`

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,14 +69,7 @@ mod tests {
             _ => panic!("gets_error_error should result in IResult::Err"),
         }
 
-        let bnf_error: Result<String, Error> = Err(Error::from(nom_error));
-
-        assert!(
-            bnf_error.is_err(),
-            "production result should be error {bnf_error:?}"
-        );
-
-        match bnf_error.unwrap_err() {
+        match Error::from(nom_error) {
             Error::ParseError(_) => (),
             e => panic!("production error should be error parsing: {e:?}"),
         }
@@ -90,13 +83,7 @@ mod tests {
             _ => panic!("gets_error_error should result in IResult::Err"),
         };
 
-        let bnf_error: Result<String, Error> = Err(Error::from(nom_error));
-
-        assert!(
-            bnf_error.is_err(),
-            "production result should be error {bnf_error:?}"
-        );
-        match bnf_error.unwrap_err() {
+        match Error::from(nom_error) {
             Error::ParseError(_) => (),
             e => panic!("production error should be parse error: {e:?}"),
         }


### PR DESCRIPTION
This PR adds an action that can be manually triggered to handle bumping the Cargo.toml version, adding a corresponding tag to the repo, and publishing to crates.io. The full proposed process is documented in the RELEASE.md that's been added here too.

Some things I thought about then decided against before settling on this solution:
- We could potentially add another step to the action to actually create a release as well but I opted not to in order to leave some room for the kinds of unautomatable notes that should sometimes make it into a release.
- We could publish to crates automatically after creating a release manually, but then we end up needing to manually edit the version in the Cargo.toml in order for it to be in the state of code covered in the release's tag. I don't like having to remember to change the version in the Cargo.toml though, it's the part I most often forget and then trip over.

(There are also a couple fixes for clippy lints that made it in here and some fixes to other errors that showed up in CI)