### PR TITLE
Divan benchmarking PoC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ unstable = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 
 [[bench]]
-name = "bnf"
+name = "criterion"
 harness = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ features = ["derive"]
 version = "1.0.61"
 
 [dev-dependencies]
+divan = "0.1.2"
 insta = { version = "1.26.0", default-features = false }
 
 [dev-dependencies.quickcheck]
@@ -50,6 +51,10 @@ tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]
 
 [[bench]]
 name = "bnf"
+harness = false
+
+[[bench]]
+name = "divan"
 harness = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ features = ["derive"]
 version = "1.0.61"
 
 [dev-dependencies]
-divan = "0.1.2"
+divan = "0.1.4"
 insta = { version = "1.26.0", default-features = false }
 
 [dev-dependencies.quickcheck]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ features = ["derive"]
 version = "1.0.61"
 
 [dev-dependencies]
-divan = "0.1.4"
+divan = "0.1.5"
 insta = { version = "1.26.0", default-features = false }
 
 [dev-dependencies.quickcheck]

--- a/benches/README.md
+++ b/benches/README.md
@@ -34,7 +34,7 @@ These benchmarks are not run during continuous integration testing. But if a dev
 
 #### Flamegraph
 
-> CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --bench bnf -- --bench
+> CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --bench divan -- --bench
 
 `sudo` may be required for `dtrace` on macOS
 

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,32 +1,11 @@
+mod util;
+
 use bnf::Grammar;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::seq::SliceRandom;
 
-#[cfg(feature = "tracing")]
-fn init_tracing() -> impl Drop {
-    use tracing_flame::FlameLayer;
-    use tracing_subscriber::{fmt, prelude::*};
-    let filter_layer = tracing_subscriber::EnvFilter::from_default_env();
-    let fmt_layer = fmt::Layer::default();
-    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
-
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(fmt_layer)
-        .with(flame_layer)
-        .init();
-
-    _guard
-}
-
-#[cfg(not(feature = "tracing"))]
-fn init_tracing() {}
-
 fn examples(c: &mut Criterion) {
-    init_tracing();
-
-    #[cfg(feature = "tracing")]
-    let _span = tracing::span!(tracing::Level::DEBUG, "BENCH EXAMPLES").entered();
+    let _tracing = util::init_tracing();
 
     c.bench_function("parse postal", |b| {
         let input = std::include_str!("../tests/fixtures/postal_address.terminated.input.bnf");

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -76,7 +76,7 @@ mod examples {
 
         bencher.bench_local(|| {
             let input = random_walks.next().unwrap();
-            let _: Vec<_> = polish_calc_grammar.parse_input(&input).collect();
+            polish_calc_grammar.parse_input(&input).for_each(|v| _ = divan::black_box(v));
         });
     }
 

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -96,7 +96,7 @@ mod examples {
             .with_inputs(|| rng.gen_range(1..100))
             .count_inputs_as::<divan::counter::ItemsCount>()
             .bench_local_values(|parse_count| {
-                let _: Vec<_> = infinite_grammar.parse_input("").take(parse_count).collect();
+            infinite_grammar.parse_input("").take(parse_count).for_each(|v| _ = divan::black_box(v));
             });
     }
 }

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -1,0 +1,105 @@
+fn main() {
+    init_tracing();
+
+    #[cfg(feature = "tracing")]
+    let _span = tracing::span!(tracing::Level::DEBUG, "BENCH EXAMPLES").entered();
+
+    // Run registered benchmarks.
+    divan::main();
+}
+
+#[cfg(feature = "tracing")]
+fn init_tracing() -> impl Drop {
+    use tracing_flame::FlameLayer;
+    use tracing_subscriber::{fmt, prelude::*};
+    let filter_layer = tracing_subscriber::EnvFilter::from_default_env();
+    let fmt_layer = fmt::Layer::default();
+    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(flame_layer)
+        .init();
+
+    _guard
+}
+
+#[cfg(not(feature = "tracing"))]
+fn init_tracing() {}
+
+mod examples {
+    #[divan::bench]
+    fn parse_postal(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
+                let input =
+                    std::include_str!("../tests/fixtures/postal_address.terminated.input.bnf");
+                input
+            })
+            .bench_refs(|input| {
+                input.parse::<bnf::Grammar>().unwrap();
+            });
+    }
+
+    #[divan::bench]
+    fn generate_dna(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
+                let input = "<dna> ::= <base> | <base> <dna>
+            <base> ::= 'A' | 'C' | 'G' | 'T'";
+                let grammar: bnf::Grammar = input.parse().unwrap();
+                grammar
+            })
+            .bench_refs(|grammar| {
+                grammar.generate().unwrap();
+            });
+    }
+
+    #[divan::bench]
+    fn parse_polish_calculator(bencher: divan::Bencher) {
+        let polish_calc_grammar: bnf::Grammar = "<product> ::= <number> | <op> <product> <product>
+            <op> ::= '+' | '-' | '*' | '/'
+            <number> ::= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+        "
+        .parse()
+        .unwrap();
+
+        // use pseudo random for consistent metrics
+        let mut rng: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0);
+        let random_walk_count = 100usize;
+        let random_walks: Vec<_> = (0..random_walk_count)
+            .map(|_| polish_calc_grammar.generate_seeded(&mut rng).unwrap())
+            .collect();
+
+        bencher
+            .with_inputs(|| {
+                let mut rng = rng.clone();
+                use rand::seq::SliceRandom;
+                random_walks.choose(&mut rng).unwrap()
+            })
+            .bench_refs(|input| {
+                let _: Vec<_> = polish_calc_grammar.parse_input(input).collect();
+            });
+    }
+
+    #[divan::bench]
+    fn parse_infinite_nullable_grammar(bencher: divan::Bencher) {
+        let infinite_grammar: bnf::Grammar = "
+                <a> ::= '' | <b>
+                <b> ::= <a>"
+            .parse()
+            .unwrap();
+        bencher
+            .with_inputs(|| {
+                use rand::Rng;
+                let mut rng: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0);
+                let parse_count: usize = rng.gen_range(1..100);
+                parse_count
+            })
+            .input_counter(|parse_count| divan::counter::ItemsCount::new(*parse_count))
+            .bench_values(|parse_count| {
+                let _: Vec<_> = infinite_grammar.parse_input("").take(parse_count).collect();
+            })
+    }
+}

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -76,7 +76,9 @@ mod examples {
 
         bencher.bench_local(|| {
             let input = random_walks.next().unwrap();
-            polish_calc_grammar.parse_input(&input).for_each(|v| _ = divan::black_box(v));
+            polish_calc_grammar
+                .parse_input(&input)
+                .for_each(|v| _ = divan::black_box(v));
         });
     }
 
@@ -96,7 +98,10 @@ mod examples {
             .with_inputs(|| rng.gen_range(1..100))
             .count_inputs_as::<divan::counter::ItemsCount>()
             .bench_local_values(|parse_count| {
-            infinite_grammar.parse_input("").take(parse_count).for_each(|v| _ = divan::black_box(v));
+                infinite_grammar
+                    .parse_input("")
+                    .take(parse_count)
+                    .for_each(|v| _ = divan::black_box(v));
             });
     }
 }

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -78,7 +78,7 @@ mod examples {
             let input = random_walks.next().unwrap();
             polish_calc_grammar
                 .parse_input(&input)
-                .for_each(|v| _ = divan::black_box(v));
+                .for_each(divan::black_box_drop);
         });
     }
 
@@ -101,7 +101,7 @@ mod examples {
                 infinite_grammar
                     .parse_input("")
                     .take(parse_count)
-                    .for_each(|v| _ = divan::black_box(v));
+                    .for_each(divan::black_box_drop);
             });
     }
 }

--- a/benches/util.rs
+++ b/benches/util.rs
@@ -1,0 +1,20 @@
+
+#[cfg(feature = "tracing")]
+pub fn init_tracing() -> impl Drop {
+    use tracing_flame::FlameLayer;
+    use tracing_subscriber::{fmt, prelude::*};
+    let filter_layer = tracing_subscriber::EnvFilter::from_default_env();
+    let fmt_layer = fmt::Layer::default();
+    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(flame_layer)
+        .init();
+
+    _guard
+}
+
+#[cfg(not(feature = "tracing"))]
+pub fn init_tracing() {}

--- a/benches/util.rs
+++ b/benches/util.rs
@@ -1,4 +1,3 @@
-
 #[cfg(feature = "tracing")]
 pub fn init_tracing() -> impl Drop {
     use tracing_flame::FlameLayer;


### PR DESCRIPTION
Closes #138 

I ported the existing benchmarks to Divan as described in #138.

```
cargo bench -q --bench divan

Timer precision: 41 ns
divan                                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ examples                                          │               │               │               │         │
   ├─ generate_dna                     415 ns        │ 75.45 µs      │ 707 ns        │ 765.5 ns      │ 570652  │ 570652
   ├─ parse_infinite_nullable_grammar  999 ns        │ 2.995 ms      │ 106.4 µs      │ 146.1 µs      │ 34183   │ 34183
   │                                   1 Mitem/s     │ 31.04 Kitem/s │ 469.6 Kitem/s │ 335.2 Kitem/s │         │
   ├─ parse_polish_calculator          4.79 µs       │ 76.19 ms      │ 11.45 µs      │ 852.3 µs      │ 5867    │ 5867
   ╰─ parse_postal                     12.91 µs      │ 1.481 ms      │ 13.29 µs      │ 13.49 µs      │ 369045  │ 369045
```

## TODO

- [x] write up pros / cons compared to Criterion
- [x] rename benchmark file
- [ ] remove old benchmarks