### PR TITLE
Profile allocations in Divan benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ features = ["derive"]
 version = "1.0.61"
 
 [dev-dependencies]
-divan = "0.1.5"
+divan = "0.1.8"
 insta = { version = "1.26.0", default-features = false }
 
 [dev-dependencies.quickcheck]

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -1,5 +1,8 @@
 mod util;
 
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
 fn main() {
     let _tracing = util::init_tracing();
 


### PR DESCRIPTION
Divan [`0.1.6`](https://github.com/nvzqz/divan/blob/main/CHANGELOG.md#016---2023-12-13) introduced [`AllocProfiler`](https://docs.rs/divan/0.1/divan/struct.AllocProfiler.html) and recently [`0.1.8`](https://github.com/nvzqz/divan/blob/main/CHANGELOG.md#018---2023-12-19) optimized it to have a minimal footprint.

Example output:

```
divan                                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ examples                                          │               │               │               │         │
   ├─ generate_dna                     540.6 ns      │ 18.12 µs      │ 874.6 ns      │ 946.2 ns      │ 432421  │ 432421
   │                                   alloc:        │               │               │               │         │
   │                                     9           │ 16            │ 16            │ 16            │         │
   │                                     123 B       │ 211 B         │ 211 B         │ 211.1 B       │         │
   │                                   dealloc:      │               │               │               │         │
   │                                     9           │ 16            │ 16            │ 16            │         │
   │                                     123 B       │ 211 B         │ 211 B         │ 211.1 B       │         │
   │                                   grow:         │               │               │               │         │
   │                                     0           │ 0             │ 0             │ 0.007         │         │
   │                                     0 B         │ 0 B           │ 0 B           │ 0.063 B       │         │
   ├─ parse_infinite_nullable_grammar  1.166 µs      │ 1.983 ms      │ 137.7 µs      │ 186.4 µs      │ 26771   │ 26771
   │                                   857.1 Kitem/s │ 33.28 Kitem/s │ 348.5 Kitem/s │ 262.8 Kitem/s │         │
   │                                   alloc:        │               │               │               │         │
   │                                     19          │ 4405          │ 2347          │ 3338          │         │
   │                                     2.036 KB    │ 582.9 KB      │ 309 KB        │ 438.7 KB      │         │
   │                                   dealloc:      │               │               │               │         │
   │                                     19          │ 4405          │ 2347          │ 3338          │         │
   │                                     2.036 KB    │ 609.1 KB      │ 321.9 KB      │ 453.9 KB      │         │
   │                                   grow:         │               │               │               │         │
   │                                     0           │ 6             │ 5             │ 4.832         │         │
   │                                     0 B         │ 26.2 KB       │ 12.89 KB      │ 15.19 KB      │         │
   ├─ parse_polish_calculator          5.165 µs      │ 53.6 ms       │ 11.83 µs      │ 754.3 µs      │ 6632    │ 6632
   │                                   alloc:        │               │               │               │         │
   │                                     45          │ 77336         │ 66            │ 1392          │         │
   │                                     6.596 KB    │ 38.77 MB      │ 12.48 KB      │ 690.5 KB      │         │
   │                                   dealloc:      │               │               │               │         │
   │                                     45          │ 77336         │ 66            │ 1392          │         │
   │                                     9.988 KB    │ 66.04 MB      │ 19.2 KB       │ 1.18 MB       │         │
   │                                   grow:         │               │               │               │         │
   │                                     9           │ 22            │ 10            │ 11.31         │         │
   │                                     3.392 KB    │ 27.26 MB      │ 6.72 KB       │ 490.1 KB      │         │
   ╰─ parse_postal                     17.08 µs      │ 186 µs        │ 17.49 µs      │ 17.59 µs      │ 278198  │ 278198
                                       alloc:        │               │               │               │         │
                                         354         │ 354           │ 354           │ 354           │         │
                                         15 KB       │ 15 KB         │ 15 KB         │ 15 KB         │         │
                                       dealloc:      │               │               │               │         │
                                         354         │ 354           │ 354           │ 354           │         │
                                         27.95 KB    │ 27.95 KB      │ 27.95 KB      │ 27.95 KB      │         │
                                       grow:         │               │               │               │         │
                                         107         │ 107           │ 107           │ 107           │         │
                                         12.95 KB    │ 12.95 KB      │ 12.95 KB      │ 12.95 KB      │         │
```