### PR TITLE
Enable clippy lints via toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,15 @@ repository = "https://github.com/shnewto/bnf"
 
 license = "MIT"
 
+[lints.clippy]
+all = "deny"
+suspicious = "deny"
+style = "deny"
+complexity = "deny"
+perf = "deny"
+must_use_candidate = "deny"
+doc_markdown = "deny"
+
 [dependencies]
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }

--- a/benches/util.rs
+++ b/benches/util.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "tracing")]
+#[must_use]
 pub fn init_tracing() -> impl Drop {
     use tracing_flame::FlameLayer;
     use tracing_subscriber::{fmt, prelude::*};

--- a/src/earley/input_range.rs
+++ b/src/earley/input_range.rs
@@ -52,7 +52,7 @@ impl<'gram> InputRange<'gram> {
 }
 
 /// A clear view of [`InputRange`], in the format "InputRange(before | current | after)"
-/// e.g., "InputRange(["1", "+", "("] | ["2"] | ["*", "3", "-", "4", ")"])"
+/// e.g., "[`InputRange`](["1", "+", "("] | ["2"] | ["*", "3", "-", "4", ")"])"
 impl<'gram> std::fmt::Debug for InputRange<'gram> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let InputRangeOffset { start, len, .. } = self.offset;

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -46,7 +46,7 @@ impl TraversalQueue {
     }
 }
 
-/// Create a [ParseTree] starting at the root [`TraversalId`].
+/// Create a [`ParseTree`] starting at the root [`TraversalId`].
 fn parse_tree<'gram>(
     traversal_tree: &TraversalTree<'gram>,
     grammar: &ParseGrammar<'gram>,
@@ -200,7 +200,7 @@ impl<'gram> Iterator for ParseTreeIter<'gram> {
         })
     }
 }
-/// Key used for "incomplete" [`Traversal`] in [CompletionMap]
+/// Key used for "incomplete" [`Traversal`] in [`CompletionMap`]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct CompletionKey<'gram> {
     term: &'gram Term,

--- a/src/earley/traversal.rs
+++ b/src/earley/traversal.rs
@@ -21,33 +21,33 @@ pub(crate) enum TermMatch<'gram> {
 #[derive(Debug)]
 pub(crate) struct Traversal<'gram> {
     pub id: TraversalId,
-    /// The unmatched "right hand side" [Term]s
+    /// The unmatched "right hand side" [`Term]s
     pub unmatched: &'gram [crate::Term],
     /// The input text available for parsing
     pub input_range: InputRange<'gram>,
-    /// Unique ID for the [Production] used to begin this [Traversal]
+    /// Unique ID for the [Production] used to begin this [`Traversal`]
     pub production_id: ProductionId,
-    /// Flag indicating that this [Traversal] began at the start of parsing,
+    /// Flag indicating that this [`Traversal`] began at the start of parsing,
     /// and if fully completed then qualifies as a successful parse.
     pub is_starting: bool,
-    /// Reference to the parent [Traversal] which started this one.
+    /// Reference to the parent [`Traversal`] which started this one.
     from: Option<TraversalEdge<'gram>>,
 }
 
 impl<'gram> Traversal<'gram> {
     pub fn next_unmatched(&self) -> Option<&'gram Term> {
-        self.unmatched.get(0)
+        self.unmatched.first()
     }
 }
 
-/// The edge which connects [Traversal]s in a [TraversalTree]
+/// The edge which connects [`Traversal`]s in a [`TraversalTree`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct TraversalEdge<'gram> {
     pub term: TermMatch<'gram>,
     pub parent_id: TraversalId,
 }
 
-/// The root in a [TraversalTree].
+/// The root in a [`TraversalTree`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct TraversalRoot {
     production_id: super::grammar::ProductionId,
@@ -58,12 +58,12 @@ type TraversalArena<'gram> = AppendOnlyVec<Traversal<'gram>, TraversalId>;
 type TreeRootMap = HashMap<TraversalRoot, TraversalId>;
 type TreeEdgeMap<'gram> = HashMap<TraversalEdge<'gram>, TraversalId>;
 
-/// Iterator of [TermMatch] which resulted in the [Traversal].
-/// Walks a [TraversalTree] from [TraversalRoot] along [TraversalEdge].
+/// Iterator of [`TermMatch`] which resulted in the [`Traversal`].
+/// Walks a [`TraversalTree`] from [`TraversalRoot`] along [`TraversalEdge`].
 ///
-/// Because [Traversal] only know their immediate parent, this iterator walks the [TraversalTree]
-/// in a silly way. Starting at the leaf, it walks up and up until finding the next desired [Traversal].
-/// This leads to wasted and repeated walking of [TraversalEdge]s. But in practice, this wasted tree
+/// Because [`Traversal`] only know their immediate parent, this iterator walks the [`TraversalTree`]
+/// in a silly way. Starting at the leaf, it walks up and up until finding the next desired [`Traversal`].
+/// This leads to wasted and repeated walking of [`TraversalEdge`]s. But in practice, this wasted tree
 /// walking seems preferable to alternatives.
 #[derive(Debug)]
 pub(crate) struct TraversalMatchIter<'gram, 'tree> {
@@ -112,7 +112,7 @@ impl<'gram, 'tree> Iterator for TraversalMatchIter<'gram, 'tree> {
     }
 }
 
-/// A tree of [Traversal], with [TermMatch] used for edges.
+/// A tree of [`Traversal`], with [`TermMatch`] used for edges.
 /// Earley "predictions" start a tree root, and each scan/complete creates child nodes. e.g.
 /// ```txt
 /// <start> ::= • <a>        (this is the root of the prediction tree)
@@ -165,7 +165,7 @@ impl<'gram> TraversalTree<'gram> {
 
         *traversal_root
     }
-    /// Same as [TraversalTree::predict] but flagging the [Traversal] as a parsing starting point
+    /// Same as [`TraversalTree::predict`] but flagging the [`Traversal`] as a parsing starting point
     pub fn predict_starting(
         &mut self,
         production: &Production<'gram>,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,11 +14,13 @@ pub struct Expression {
 
 impl Expression {
     /// Construct a new `Expression`
+    #[must_use]
     pub fn new() -> Expression {
         Expression { terms: vec![] }
     }
 
     /// Construct an `Expression` from `Term`s
+    #[must_use]
     pub fn from_parts(v: Vec<Term>) -> Expression {
         Expression { terms: v }
     }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -126,6 +126,7 @@ impl<'gram> ParseTree<'gram> {
     /// let mermaid = parsed.mermaid().to_string();
     /// println!("parse tree mermaid: {}", mermaid);
     /// ```
+    #[must_use]
     pub fn mermaid(&self) -> MermaidParseTree<'_> {
         MermaidParseTree { parse_tree: self }
     }
@@ -210,6 +211,7 @@ pub struct Grammar {
 
 impl Grammar {
     /// Construct a new `Grammar`
+    #[must_use]
     pub fn new() -> Grammar {
         Grammar {
             productions: vec![],
@@ -217,6 +219,7 @@ impl Grammar {
     }
 
     /// Construct an `Grammar` from `Production`s
+    #[must_use]
     pub fn from_parts(v: Vec<Production>) -> Grammar {
         Grammar { productions: v }
     }

--- a/src/production.rs
+++ b/src/production.rs
@@ -19,6 +19,7 @@ pub struct Production {
 
 impl Production {
     /// Construct a new `Production`
+    #[must_use]
     pub fn new() -> Production {
         Production {
             lhs: Term::Nonterminal(String::new()),
@@ -27,6 +28,7 @@ impl Production {
     }
 
     /// Construct an `Production` from `Expression`s
+    #[must_use]
     pub fn from_parts(t: Term, e: Vec<Expression>) -> Production {
         Production { lhs: t, rhs: e }
     }
@@ -60,11 +62,13 @@ impl Production {
     }
 
     /// Get number of right hand side `Expression`s
+    #[must_use]
     pub fn len(&self) -> usize {
         self.rhs.len()
     }
 
     /// If the production is empty of `Expression`s
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.rhs.is_empty()
     }


### PR DESCRIPTION
Cargo/clippy recently added [support](https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section) for configuring lints via the `Cargo.toml`. This configures clippy lints and helps them be reliable for all contributors. And creates a central place to configure them!