### PR TITLE
use hashbrown as internal hashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ missing_const_for_fn = "deny"
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }
 tracing-flame = { version = "0.2.0", optional = true }
+hashbrown = "0.14.3"
 
 [dependencies.rand]
 version = "0.8.0"

--- a/src/earley/grammar.rs
+++ b/src/earley/grammar.rs
@@ -13,7 +13,7 @@ pub(crate) struct Production<'gram> {
 }
 
 type ProdArena<'gram> = AppendOnlyVec<Production<'gram>, ProductionId>;
-type ProdTermMap<'gram> = std::collections::HashMap<&'gram crate::Term, Vec<ProductionId>>;
+type ProdTermMap<'gram> = crate::HashMap<&'gram crate::Term, Vec<ProductionId>>;
 
 /// Similar to [`crate::Grammar`], but using [`Production`] and tables useful for parsing.
 #[derive(Debug)]

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -5,7 +5,7 @@ mod traversal;
 use crate::{tracing, ParseTree, ParseTreeNode, Term};
 use grammar::{ParseGrammar, Production};
 use input_range::InputRange;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use traversal::{TermMatch, Traversal, TraversalId, TraversalTree};
 
 pub fn parse<'gram>(
@@ -224,8 +224,8 @@ impl<'gram> CompletionKey<'gram> {
 
 #[derive(Debug, Default)]
 pub(crate) struct CompletionMap<'gram> {
-    incomplete: HashMap<CompletionKey<'gram>, BTreeSet<TraversalId>>,
-    complete: HashMap<CompletionKey<'gram>, BTreeSet<TraversalId>>,
+    incomplete: crate::HashMap<CompletionKey<'gram>, BTreeSet<TraversalId>>,
+    complete: crate::HashMap<CompletionKey<'gram>, BTreeSet<TraversalId>>,
 }
 
 impl<'gram> CompletionMap<'gram> {

--- a/src/earley/traversal.rs
+++ b/src/earley/traversal.rs
@@ -3,7 +3,6 @@ use crate::{
     append_vec::{append_only_vec_id, AppendOnlyVec},
     tracing, Term,
 };
-use std::collections::HashMap;
 
 append_only_vec_id!(pub(crate) TraversalId);
 
@@ -55,8 +54,8 @@ struct TraversalRoot {
 }
 
 type TraversalArena<'gram> = AppendOnlyVec<Traversal<'gram>, TraversalId>;
-type TreeRootMap = HashMap<TraversalRoot, TraversalId>;
-type TreeEdgeMap<'gram> = HashMap<TraversalEdge<'gram>, TraversalId>;
+type TreeRootMap = crate::HashMap<TraversalRoot, TraversalId>;
+type TreeEdgeMap<'gram> = crate::HashMap<TraversalEdge<'gram>, TraversalId>;
 
 /// Iterator of [`TermMatch`] which resulted in the [`Traversal`].
 /// Walks a [`TraversalTree`] from [`TraversalRoot`] along [`TraversalEdge`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,5 @@ pub use crate::expression::Expression;
 pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
+
+pub(crate) use hashbrown::HashMap;


### PR DESCRIPTION
hashbrown is the same hashmap used by the std library. however the std library uses some safer defaults (denial-of-service resistant hashing) and is a few versions behind. 

these differences may lead to performance loss when not required.

using hashbrown in BNF improved _all_ benchmarks on my local machine by 2-25%.

for this reason, it seems worth BNF adopting hashbrown as its default hasher.

the denial-of-service resistance is not required for BNF's use cases