### PR TITLE
Macro Constructors

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::vec_init_then_push)]
+
 use crate::error::Error;
 use crate::parsers;
 use crate::term::Term;
@@ -105,7 +107,7 @@ macro_rules! expression {
     // rule which matches <ident> followed by token tree
     (<$nt:ident> $($tt:tt)*) => {
         {
-            let mut vec = Vec::new();
+            let mut vec = vec![];
             $crate::expression!(vec; <$nt> $($tt)*);
             $crate::Expression::from_parts(vec)
         }
@@ -113,8 +115,8 @@ macro_rules! expression {
     // rule which matches literal followed by token tree
     ($t:literal $($tt:tt)*) => {
         {
-            let mut vec = Vec::new();
-            $crate::crate::expression!(vec; $t $($tt)*);
+            let mut vec = vec![];
+            $crate::expression!(vec; $t $($tt)*);
             $crate::Expression::from_parts(vec)
         }
     };

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::vec_init_then_push)]
+
 use crate::error::Error;
 use crate::expression::Expression;
 use crate::parsers;

--- a/src/production.rs
+++ b/src/production.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::should_implement_trait)]
+#![allow(clippy::vec_init_then_push)]
 
 use crate::error::Error;
 use crate::expression::Expression;

--- a/src/production.rs
+++ b/src/production.rs
@@ -116,6 +116,45 @@ impl FromStr for Production {
     }
 }
 
+/// Macro to create a `Production` from a right-hand side definition
+/// ```
+/// bnf::production!(<S> ::= 'T' <NT> | <NT> "AND");
+/// ```
+#[macro_export]
+macro_rules! production {
+    (<$lhs:ident> ::= $($rest:tt)*) => {
+        {
+            let mut expressions = vec![];
+            let mut terms = vec![];
+            $crate::production!(@rhs expressions terms $($rest)*);
+            expressions.push($crate::Expression::from_parts(terms));
+            $crate::Production::from_parts(
+                $crate::term!(<$lhs>),
+                expressions,
+            )
+        }
+    };
+    // munch rhs until empty
+    // if terminal, add to expression
+    (@rhs $expr:ident $terms:ident $t:literal $($rest:tt)*) => {
+        $terms.push($crate::term!($t));
+        $crate::production!(@rhs $expr $terms $($rest)*);
+    };
+    // if nonterminal, add to expression and keep munching
+    (@rhs $expr:ident $terms:ident <$nt:ident> $($rest:tt)*) => {
+        $terms.push($crate::term!(<$nt>));
+        $crate::production!(@rhs $expr $terms $($rest)*);
+    };
+    // if | add expression to production, and create new expression
+    (@rhs $expr:ident $terms:ident | $($rest:tt)*) => {
+        $expr.push($crate::Expression::from_parts($terms));
+        $terms = vec![];
+        $crate::production!(@rhs $expr $terms $($rest)*);
+    };
+    // base case
+    (@rhs $expr:ident $terms:ident) => {};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,5 +431,26 @@ mod tests {
             &Term::from_str("<NTc>").unwrap(),
             &Term::from_str("<NTd>").unwrap(),
         ])));
+    }
+
+    #[test]
+    fn macro_builds_todo() {
+        let production = crate::production!(<S> ::= 'T' <NT> | <NT> "AND");
+
+        let expected = Production::from_parts(
+            Term::Nonterminal(String::from("S")),
+            vec![
+                Expression::from_parts(vec![
+                    Term::Terminal(String::from("T")),
+                    Term::Nonterminal(String::from("NT")),
+                ]),
+                Expression::from_parts(vec![
+                    Term::Nonterminal(String::from("NT")),
+                    Term::Terminal(String::from("AND")),
+                ]),
+            ],
+        );
+
+        assert_eq!(production, expected);
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -20,6 +20,25 @@ pub enum Term {
     Nonterminal(String),
 }
 
+/// Creates a Terminal if the input is a string literal or a Nonterminal if the input is inside angle brackets
+/// ```
+/// bnf::term!("terminal");
+/// bnf::term!(<nonterminal>);
+/// ```
+#[macro_export]
+macro_rules! term {
+    (<$ident:ident>) => {
+        $crate::Term::Nonterminal(stringify!($ident).to_string())
+    };
+    ($ident:ident) => {
+        $crate::Term::Terminal(stringify!($ident).to_string())
+    };
+    // another case for string literal
+    ($ident:literal) => {
+        $crate::Term::Terminal($ident.to_string())
+    };
+}
+
 impl FromStr for Term {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -208,5 +227,17 @@ mod tests {
         assert_eq!(e1, e2);
         assert_eq!(e1, e3);
         assert_eq!(e1, e4);
+    }
+
+    #[test]
+    fn macro_terminal() {
+        let terminal = term!("terminal");
+        assert_eq!(Term::Terminal(String::from("terminal")), terminal);
+    }
+
+    #[test]
+    fn macro_nonterminal() {
+        let nonterminal = term!(<nonterminal>);
+        assert_eq!(Term::Nonterminal(String::from("nonterminal")), nonterminal);
     }
 }


### PR DESCRIPTION
# What

Adds macro constructors for each of the base BNF types (terms/expressions/productions/grammars)

```rust
let dna_grammar = bnf::grammar! {
  <dna> ::= <base> | <base> <dna>;
  <base> ::= 'A' | 'C' | 'G' | 'T';
};
```

# How

Via not very easy to read, and hard to test `macro_rules` 😅

# Why

* sometimes writing a macro is nice because it is shorter than `<prod> ::= 'A'".parse()`
* it is definitely shorter than the `*::from_parts` constructors

# Why Not

* `macro_rules` are hard to reason about, debug, and test
* maybe offering multiple ways to do the same thing is confusing to users
  * for example, because whitespace is not a token, semicolons are a hard requirement for parsing a Grammar via macros

# Future Dreams

The main motivation for this was to see if maybe a `const` constructor would be possible. The current macros do not support that due to vector mutations, but I think it may be doable. Unfortunately, a full macro `const` constructor would require:

* Terms to hold `Cow<str>`, not `String`
* Grammar/Prod/Expression would need to hold `Cow<[T]>`, not `Vec<T>`

This is doable, but would definitely introduce many breaking changes.

# Open Questions

* is this more useful than confusing?
* is the future dream of a `const` constructor worth breaking changes?
