### PR TITLE
added Format trait to support different BNF syntaxes, and a basic implementation of ABNF  to demonstrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,8 @@ version = "0.5.0"
 default-features = false # to disable Rayon for wasm32
 
 [features]
-default = ["serde"]
+default = ["ABNF", "serde"]
+ABNF = []
 serde = ["dep:serde", "dep:serde_json"]
 unstable = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:tracing-flame"]

--- a/src/augmented.rs
+++ b/src/augmented.rs
@@ -10,6 +10,7 @@ use nom::{
     IResult,
 };
 
+#[non_exhaustive]
 pub struct ABNF;
 
 impl Format for ABNF {

--- a/src/augmented.rs
+++ b/src/augmented.rs
@@ -26,6 +26,7 @@ impl Format for ABNF {
         not(complete::char('\''))(input)?;
         not(complete::char('\"'))(input)?;
         not(complete::char('|'))(input)?;
+        not(complete::char(';'))(input)?;
         let (input, nt) = complete(terminated(
             take_till(char::is_whitespace),
             complete::multispace0,

--- a/src/augmented.rs
+++ b/src/augmented.rs
@@ -3,7 +3,7 @@ use crate::term::Term;
 
 use nom::{
     bytes::complete::{tag, take, take_till},
-    character::complete,
+    character::complete::{self, satisfy},
     combinator::{complete, not},
     error::VerboseError,
     sequence::{preceded, terminated},
@@ -23,10 +23,7 @@ impl Format for ABNF {
     }
 
     fn nonterminal(input: &str) -> IResult<&str, Term, VerboseError<&str>> {
-        not(complete::char('\''))(input)?;
-        not(complete::char('\"'))(input)?;
-        not(complete::char('|'))(input)?;
-        not(complete::char(';'))(input)?;
+        satisfy(|c: char| c.is_alphanumeric() || c == '_')(input)?;
         let (input, nt) = complete(terminated(
             take_till(char::is_whitespace),
             complete::multispace0,

--- a/src/augmented.rs
+++ b/src/augmented.rs
@@ -15,15 +15,12 @@ pub struct ABNF;
 impl Format for ABNF {
     fn prod_lhs(input: &str) -> IResult<&str, Term, VerboseError<&str>> {
         let (input, nt) = take_till(char::is_whitespace)(input)?;
-    
-        let (input, _) = preceded(
-            complete::multispace0,
-            complete::char('='),
-        )(input)?;
-    
+
+        let (input, _) = preceded(complete::multispace0, complete::char('='))(input)?;
+
         Ok((input, Term::Nonterminal(nt.to_string())))
     }
-    
+
     fn nonterminal(input: &str) -> IResult<&str, Term, VerboseError<&str>> {
         not(complete::char('\''))(input)?;
         not(complete::char('\"'))(input)?;
@@ -33,9 +30,9 @@ impl Format for ABNF {
             complete::multispace0,
         ))(input)?;
         take(1_usize)(nt)?;
-    
+
         not(complete(tag("=")))(input)?;
-    
+
         Ok((input, Term::Nonterminal(nt.to_string())))
     }
 }
@@ -45,10 +42,10 @@ mod tests {
     use super::ABNF;
     use crate::parsers::*;
 
-    use crate::term::Term;
     use crate::expression::Expression;
     use crate::grammar::Grammar;
     use crate::production::Production;
+    use crate::term::Term;
 
     fn construct_nonterminal_tuple() -> (Term, String) {
         let nonterminal_pattern = "nonterminal-pattern";

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::vec_init_then_push)]
 
 use crate::error::Error;
-use crate::parsers;
+use crate::parsers::{self, BNF};
 use crate::term::Term;
 use std::fmt;
 use std::ops;
@@ -151,7 +151,7 @@ impl FromStr for Expression {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parsers::expression_complete(s) {
+        match parsers::expression_complete::<BNF>(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -228,7 +228,6 @@ impl Grammar {
     }
 
     /// parse a grammar given a format
-
     pub fn parse_from<F: Format>(input: &str) -> Result<Self, self::Error> {
         match parsers::grammar_complete::<F>(input) {
             Result::Ok((_, o)) => Ok(o),

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,10 +1,12 @@
 #![allow(clippy::vec_init_then_push)]
 
+use crate::augmented;
 use crate::error::Error;
 use crate::expression::Expression;
 use crate::parsers;
 use crate::production::Production;
 use crate::term::Term;
+use crate::Format;
 use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
 
 #[cfg(feature = "serde")]
@@ -225,6 +227,21 @@ impl Grammar {
     #[must_use]
     pub const fn from_parts(v: Vec<Production>) -> Grammar {
         Grammar { productions: v }
+    }
+
+    /// parse a grammar given a format
+
+    pub fn parse_from(input: &str, f: Format) -> Result<Self, self::Error> {
+        match f {
+            Format::BNF => match parsers::grammar_complete(input) {
+                    Result::Ok((_, o)) => Ok(o),
+                    Result::Err(e) => Err(Error::from(e)),
+            },
+            Format::ABNF => match augmented::grammar_complete(input) {
+                    Result::Ok((_, o)) => Ok(o),
+                    Result::Err(e) => Err(Error::from(e)),
+            },
+        }
     }
 
     /// Add `Production` to the `Grammar`

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -232,7 +232,7 @@ impl Grammar {
     pub fn parse_from<F: Format>(input: &str) -> Result<Self, self::Error> {
         match parsers::grammar_complete::<F>(input) {
             Result::Ok((_, o)) => Ok(o),
-            Result::Err(e) => Err(Error::from(e))
+            Result::Err(e) => Err(Error::from(e)),
         }
     }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::vec_init_then_push)]
 
-use crate::augmented;
 use crate::error::Error;
 use crate::expression::Expression;
-use crate::parsers;
+use crate::parsers::{self, Format, BNF};
 use crate::production::Production;
 use crate::term::Term;
-use crate::Format;
 use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
 
 #[cfg(feature = "serde")]
@@ -231,16 +229,10 @@ impl Grammar {
 
     /// parse a grammar given a format
 
-    pub fn parse_from(input: &str, f: Format) -> Result<Self, self::Error> {
-        match f {
-            Format::BNF => match parsers::grammar_complete(input) {
-                    Result::Ok((_, o)) => Ok(o),
-                    Result::Err(e) => Err(Error::from(e)),
-            },
-            Format::ABNF => match augmented::grammar_complete(input) {
-                    Result::Ok((_, o)) => Ok(o),
-                    Result::Err(e) => Err(Error::from(e)),
-            },
+    pub fn parse_from<F: Format>(input: &str) -> Result<Self, self::Error> {
+        match parsers::grammar_complete::<F>(input) {
+            Result::Ok((_, o)) => Ok(o),
+            Result::Err(e) => Err(Error::from(e))
         }
     }
 
@@ -511,7 +503,7 @@ impl str::FromStr for Grammar {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parsers::grammar_complete(s) {
+        match parsers::grammar_complete::<BNF>(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
 
-pub use parsers::Format;
+pub use parsers::{Format, BNF};
+pub use augmented::ABNF;
 
 pub(crate) use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![doc = include_str!("../README.md")]
 
 mod append_vec;
+mod augmented;
 mod earley;
 mod error;
 mod expression;
 mod grammar;
 mod parsers;
-mod augmented;
 mod production;
 mod term;
 mod tracing;
@@ -16,7 +16,7 @@ pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
 
-pub use parsers::{Format, BNF};
 pub use augmented::ABNF;
+pub use parsers::{Format, BNF};
 
 pub(crate) use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod error;
 mod expression;
 mod grammar;
 mod parsers;
+mod augmented;
 mod production;
 mod term;
 mod tracing;
@@ -14,5 +15,7 @@ pub use crate::expression::Expression;
 pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
+
+pub use parsers::Format;
 
 pub(crate) use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod append_vec;
+#[cfg(feature = "ABNF")]
 mod augmented;
 mod earley;
 mod error;
@@ -16,6 +17,7 @@ pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
 
+#[cfg(feature = "ABNF")]
 pub use augmented::ABNF;
 pub use parsers::{Format, BNF};
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -6,7 +6,7 @@ use crate::term::Term;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_till, take_until},
-    character::complete,
+    character::complete::{self, multispace0},
     combinator::{all_consuming, complete, eof, not, peek, recognize},
     error::VerboseError,
     multi::{many0, many1},
@@ -70,6 +70,16 @@ pub fn comment(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
     )(input)?;
     not(complete::char(';'))(input)?;
     Ok((input, comment))
+}
+
+pub fn is_format_standard_bnf(input: &str) -> bool {
+    match terminated(many0(preceded(multispace0, comment)), multispace0)(input) {
+        Ok(tuple) => {
+            let (input, _) = tuple;
+            complete::char::<&str, VerboseError<&str>>('<')(input).is_ok()
+        }
+        Err(_) => unreachable!("this pattern should always match"),
+    }
 }
 
 pub fn term<F: Format>(input: &str) -> IResult<&str, Term, VerboseError<&str>> {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -20,6 +20,7 @@ pub trait Format {
     fn nonterminal(input: &str) -> IResult<&str, Term, VerboseError<&str>>;
 }
 
+#[non_exhaustive]
 pub struct BNF;
 
 impl Format for BNF {

--- a/src/production.rs
+++ b/src/production.rs
@@ -3,7 +3,7 @@
 
 use crate::error::Error;
 use crate::expression::Expression;
-use crate::parsers;
+use crate::parsers::{self, BNF};
 use crate::term::Term;
 use std::fmt;
 
@@ -110,7 +110,7 @@ impl fmt::Display for Production {
 impl FromStr for Production {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parsers::production_complete(s) {
+        match parsers::production_complete::<BNF>(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -2,7 +2,7 @@
 
 use crate::error::Error;
 use crate::expression::Expression;
-use crate::parsers;
+use crate::parsers::{self, BNF};
 use std::fmt;
 use std::ops;
 use std::str::FromStr;
@@ -42,7 +42,7 @@ macro_rules! term {
 impl FromStr for Term {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match parsers::term_complete(s) {
+        match parsers::term_complete::<BNF>(s) {
             Result::Ok((_, o)) => Ok(o),
             Result::Err(e) => Err(Error::from(e)),
         }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -16,7 +16,7 @@ mod defs {
     pub struct Span {}
 
     impl Span {
-        pub fn entered(&self) -> Self {
+        pub const fn entered(&self) -> Self {
             Self {}
         }
     }
@@ -42,7 +42,7 @@ mod defs {
     pub(crate) use event;
 
     #[allow(dead_code)]
-    pub fn init_subscriber() {}
+    pub const fn init_subscriber() {}
 }
 
 pub(crate) use defs::*;

--- a/tests/fixtures/abnf.abnf
+++ b/tests/fixtures/abnf.abnf
@@ -1,0 +1,37 @@
+syntax         = rule | rule syntax
+rule           = opt-whitespace "<" rule-name ">"
+                     opt-whitespace "::=" opt-whitespace
+                     expression line-end
+opt-whitespace = "" | " " opt-whitespace
+expression     = list | list opt-whitespace "|"
+                     opt-whitespace expression
+line-end       = opt-whitespace EOL
+list           = term | term opt-whitespace list
+term           = literal | "<" rule-name ">"
+literal        = '"' text1 '"' | "'" text2 "'"
+text1          = "" | character1 text1
+text2          = "" | character2 text2
+character      = letter | digit | symbol
+letter         = "A" | "B" | "C" | "D" | "E" | "F"
+                    | "G" | "H" | "I" | "J" | "K" | "L"
+                    | "M" | "N" | "O" | "P" | "Q" | "R"
+                    | "S" | "T" | "U" | "V" | "W" | "X"
+                    | "Y" | "Z" | "a" | "b" | "c" | "d"
+                    | "e" | "f" | "g" | "h" | "i" | "j"
+                    | "k" | "l" | "m" | "n" | "o" | "p"
+                    | "q" | "r" | "s" | "t" | "u" | "v"
+                    | "w" | "x" | "y" | "z"
+digit          = "0" | "1" | "2" | "3" | "4" | "5"
+                    | "6" | "7" | "8" | "9"
+symbol         =  "|" | " " | "-" | "!" | "#" | "$"
+                    | "%" | "&" | "(" | ")" | "*" | "+"
+                    | "," | "-" | "." | "/" | ":" | ";"
+                    |">" | "=" | "<" | "?" | "@" | "["
+                    | "\\" | "]" | "^" | "_" | "`"
+                    | "{{" | "}}" | "~"
+character1     = character | "'"
+character2     = character | '"'
+rule-name      = letter | rule-name rule-char
+rule-char      = letter | digit | "-"
+EOL            = "
+"

--- a/tests/fixtures/abnf.abnf
+++ b/tests/fixtures/abnf.abnf
@@ -3,14 +3,17 @@ rule           = opt-whitespace "<" rule-name ">"
                      opt-whitespace "::=" opt-whitespace
                      expression line-end
 opt-whitespace = "" | " " opt-whitespace
+;this is a comment
 expression     = list | list opt-whitespace "|"
                      opt-whitespace expression
 line-end       = opt-whitespace EOL
-list           = term | term opt-whitespace list
+list           = term | term opt-whitespace list ;s0 !s thi$
 term           = literal | "<" rule-name ">"
 literal        = '"' text1 '"' | "'" text2 "'"
 text1          = "" | character1 text1
-text2          = "" | character2 text2
+text2          = "" | character2 text2 ;multiple  
+    ;comments
+                                    ;in a row!
 character      = letter | digit | symbol
 letter         = "A" | "B" | "C" | "D" | "E" | "F"
                     | "G" | "H" | "I" | "J" | "K" | "L"

--- a/tests/fixtures/bnf.bnf
+++ b/tests/fixtures/bnf.bnf
@@ -6,11 +6,12 @@
 <expression>     ::= <list> | <list> <opt-whitespace> "|"
                      <opt-whitespace> <expression>
 <line-end>       ::= <opt-whitespace> <EOL>
+;that's just how it goes
 <list>           ::= <term> | <term> <opt-whitespace> <list>
 <term>           ::= <literal> | "<" <rule-name> ">"
 <literal>        ::= '"' <text1> '"' | "'" <text2> "'"
 <text1>          ::= "" | <character1> <text1>
-<text2>          ::= "" | <character2> <text2>
+<text2>          ::= "" | <character2> <text2> ;random comment
 <character>      ::= <letter> | <digit> | <symbol>
 <letter>         ::= "A" | "B" | "C" | "D" | "E" | "F"
                     | "G" | "H" | "I" | "J" | "K" | "L"
@@ -35,3 +36,4 @@
 <rule-char>      ::= <letter> | <digit> | "-"
 <EOL>            ::= "
 "
+;last thing, i promise...

--- a/tests/fixtures/bnf.bnf
+++ b/tests/fixtures/bnf.bnf
@@ -1,3 +1,5 @@
+;autodetection of grammar accounts for comments!(sic)
+
 <syntax>         ::= <rule> | <rule> <syntax>
 <rule>           ::= <opt-whitespace> "<" <rule-name> ">"
                      <opt-whitespace> "::=" <opt-whitespace>

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use bnf::{Grammar, ABNF, BNF};
+use bnf::Grammar;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -17,10 +17,10 @@ const ABNF_FOR_BNF: &str = std::include_str!("./fixtures/abnf.abnf");
 impl Arbitrary for Meta {
     fn arbitrary(gen: &mut Gen) -> Meta {
         // Generate Grammar object from grammar for BNF grammars
-        let grammar_bnf: Result<Grammar, _> = Grammar::parse_from::<BNF>(BNF_FOR_BNF);
+        let grammar_bnf: Result<Grammar, _> = BNF_FOR_BNF.parse();
         assert!(grammar_bnf.is_ok(), "{grammar_bnf:?} should be Ok");
 
-        let grammar_abnf: Result<Grammar, _> = Grammar::parse_from::<ABNF>(ABNF_FOR_BNF);
+        let grammar_abnf: Result<Grammar, _> = ABNF_FOR_BNF.parse();
         assert!(grammar_abnf.is_ok(), "{grammar_abnf:?} should be Ok");
 
         assert_eq!(grammar_bnf, grammar_abnf);

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use bnf::{Grammar, BNF, ABNF};
+use bnf::{Grammar, ABNF, BNF};
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -20,11 +20,13 @@ impl Arbitrary for Meta {
         let grammar_bnf: Result<Grammar, _> = BNF_FOR_BNF.parse();
         assert!(grammar_bnf.is_ok(), "{grammar_bnf:?} should be Ok");
 
-        let grammar_abnf: Result<Grammar, _> = ABNF_FOR_BNF.parse();
-        assert!(grammar_abnf.is_ok(), "{grammar_abnf:?} should be Ok");
+        #[cfg(feature = "ABNF")]
+        {
+            let grammar_abnf: Result<Grammar, _> = ABNF_FOR_BNF.parse();
+            assert!(grammar_abnf.is_ok(), "{grammar_abnf:?} should be Ok");
 
-        assert_eq!(grammar_bnf, grammar_abnf);
-
+            assert_eq!(grammar_bnf, grammar_abnf);
+        }
         // generate a random valid grammar from the above
         // using an arbitrary seed
         let seed: [u8; 32] = {

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use bnf::Grammar;
+use bnf::{Grammar, BNF, ABNF};
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -12,12 +12,18 @@ struct Meta {
 // Modified version of BNF for BNF from
 // https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Further_examples
 const BNF_FOR_BNF: &str = std::include_str!("./fixtures/bnf.bnf");
+const ABNF_FOR_BNF: &str = std::include_str!("./fixtures/abnf.abnf");
 
 impl Arbitrary for Meta {
     fn arbitrary(gen: &mut Gen) -> Meta {
         // Generate Grammar object from grammar for BNF grammars
-        let grammar: Result<Grammar, _> = BNF_FOR_BNF.parse();
-        assert!(grammar.is_ok(), "{grammar:?} should be Ok");
+        let grammar_bnf: Result<Grammar, _> = Grammar::parse_from::<BNF>(BNF_FOR_BNF);
+        assert!(grammar_bnf.is_ok(), "{grammar_bnf:?} should be Ok");
+
+        let grammar_abnf: Result<Grammar, _> = Grammar::parse_from::<ABNF>(ABNF_FOR_BNF);
+        assert!(grammar_abnf.is_ok(), "{grammar_abnf:?} should be Ok");
+
+        assert_eq!(grammar_bnf, grammar_abnf);
 
         // generate a random valid grammar from the above
         // using an arbitrary seed
@@ -32,7 +38,7 @@ impl Arbitrary for Meta {
         };
 
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let sentence = grammar.unwrap().generate_seeded(&mut rng);
+        let sentence = grammar_bnf.unwrap().generate_seeded(&mut rng);
 
         match sentence {
             Err(e) => {


### PR DESCRIPTION
i'm curious too hear peoples thoughts about this approach, other approaches i considered are:

```functional programming``` 
by this i mean making all the basic parsing functions higher-order functions 
so you'd pass the format as a normal parameter and it 'binds' the parameter, returning a closure that has it 
built in and thus can be composed with ```nom``` combinators

```i rejected it because``` 
it seems massively complicated to me and the use of closures would change the performance characteristics(EDIT: sic, we already use closures but they're monomorphized at compile-time, that's the whole idea behind ```nom```)

```global variables``` 
pretty self-explanatory, you have a ```static``` format with a setter and getter to hide how it's implemented, 
could be through a ```RwLock```, i even tried an unsafe ```static mut``` because i wasn't sure that generating 
multiple BNF's of different formats in parallel was really desirable to support

```i rejected it because``` 
aside from my obvious unease about globals, it turns out that it breaks the whole test suite in 
unpredictable ways because reason tests all "see" the same global variable, having the tests that use 
ABNF set it back to the default afterwards and using the  ```RwLock``` implementation helped a bit, 
but i think i'd have to rewrite all the tests to make sure this new "environment" is set correctly and i' don't see 
why i should when other options set the bar much higher

```code duplication```
the idea is i just copy and paste the entirety of parsers.rs into a new module and just change the low-level 
```prod_lhs()``` and ```nonterminal```, this was what i tried at first, you can see it working in the second commit
 here, this option is already pretty good because there's not much code to duplicate and it's not very complex

i only rejected code duplication because i think the ```Format``` trait is a better way of generating the same code 
but with the duplication done automatically so it's always in sync, at the minor cost of always requiring a type parameter, 
even up to the interface, i wanted to have it be an argument in the API at first but now that would be misleading as to how 
it works, no data is actually transferred at runtime 

