### PR TITLE
Re-export `rand`

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -347,7 +347,7 @@ impl Grammar {
     /// # Example
     ///
     /// ```rust
-    /// use rand::{SeedableRng, rngs::StdRng};
+    /// use bnf::rand::{SeedableRng, rngs::StdRng};
     /// use bnf::Grammar;
     ///
     /// let input =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub use crate::grammar::{Grammar, ParseTree, ParseTreeNode};
 pub use crate::production::Production;
 pub use crate::term::Term;
 
+// The version of `rand` used by the public API.
+pub use rand;
+
 #[cfg(feature = "ABNF")]
 pub use parsers::ABNF;
 pub use parsers::{BNF, Format};


### PR DESCRIPTION
Just a small improvement (imo) to the developer experience 😄 

`rand::rngs::StdRng` is part of `bnf`'s public API, so users must have the correct version of `rand` installed.

When you also have different uses for `rand` in your codebase, you might end up doing something like this in Cargo.toml:
```toml
[dependencies]
# latest version
rand = "0.9"
# for `bnf`, will have to manually update when `bnf 0.6` comes out.
rand_08 = { package = "rand", version = "0.8" }
bnf = "0.5"
```
(example is for the current published state on crates.io and doesn't apply on `main`, but it could happen again in the future when `rand` releases a new version.)

By re-exporting `rand` from `bnf`, users can easily use any version they like for other purposes and use bnf's version when using `bnf`.

```rs
use bnf::rand::{SeedableRng, rngs::StdRng}; // always the right version
```