### PR TITLE
Fix markdown formatting standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,16 +7,19 @@ labels: ''
 ---
 
 **Describe the bug**
-Usually helps to describe the behavior you're seeing vs what you expected to see.
+Usually helps to describe the behavior you're seeing vs what you expected to
+see.
 
 **To Reproduce**
-Steps to reproduce the behavior. If there's input that causes this, that'd be really helpful to include here!
+Steps to reproduce the behavior. If there's input that causes this, that'd be
+really helpful to include here!
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS and version, i.e. macOS Big Sur 11.1
+
+- OS and version, i.e. macOS Big Sur 11.1
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,11 @@
-If you're not sure what to write, here's a bit of an outline to get you started. No requirement to conform though if you're comfortable providing some appropriate info. 
+# Pull Request Template
+
+If you're not sure what to write, here's a bit of an outline to get you started.
+No requirement to conform though if you're comfortable providing some
+appropriate info.
 
 - Title / short summary of the changes in this PR
 - Prior to this PR ____ / how things were and why things needed to change
 - After this PR ____ / how things have changed
-- Note design decisions / anything that may not be immediately evident when reading the diffs
+- Note design decisions / anything that may not be immediately evident when
+  reading the diffs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,11 +55,12 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at bnf@shnewto.dev. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project team at
+[bnf@shnewto.dev](mailto:bnf@shnewto.dev). All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -67,10 +68,11 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[FAQ](https://www.contributor-covenant.org/faq)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,22 @@
 
 :wave: welcome! And thanks for taking time to contribute!
 
-
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [bnf@shnewto.dev](mailto:bnf@shnewto.dev).
-
+This project and everyone participating in it is governed by the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold this code. Please report unacceptable behavior to
+[bnf@shnewto.dev](mailto:bnf@shnewto.dev).
 
 ## Questions
 
-Please feel free to raise issues to ask questions or report bugs. If you'd like to open a PR but want to touch bases first, feel free to raise an issue then too.
+Please feel free to raise issues to ask questions or report bugs. If you'd like
+to open a PR but want to touch bases first, feel free to raise an issue then
+too.
 
 ## Opening PRs
 
-Good PR comments go a long way. It means a lot (and really helps) when you take the time to explain _why_ your PR is doing what it does. 
-
+Good PR comments go a long way. It means a lot (and really helps) when you take
+the time to explain _why_ your PR is doing what it does.
 
 Thanks again!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,12 @@
 # Release Process
 
 - leave the Cargo.toml package version alone :)
-- trigger the `tag and publish crate [manual]` action and specify the release increment (major, minor, or patch)
-  - once the action completes, the Cargo.toml will be updated and the crate will be live on crates.io
-- create a release (with title, notes, thanks, etc) and tie it to the tag that was created by the action / new crate version
+- trigger the `tag and publish crate [manual]` action and specify the release
+  increment (major, minor, or patch)
+  - once the action completes, the Cargo.toml will be updated and the crate will
+    be live on crates.io
+- create a release (with title, notes, thanks, etc) and tie it to the tag that
+  was created by the action / new crate version
 
 ## Execution
 
@@ -16,7 +19,13 @@ The order of operations for tagging and publishing in the action is this
 
 ## Troubleshooting
 
-- if step 1 of execution fails, after addressing the error, you run the action again
-- if step 2 of execution fails, after addressing the error, you run the action again
-- if step 3 of execution fails (the Cargo.toml version was incremented), after addressing the error, you should manually tag (github's ux or the cli) and manually publish the crate with `cargo publish`
-- if step 4 of execution fails (the Cargo.toml version was incremented and there's a new corresponding tag), after addressing the error, you should manually publish the crate  with `cargo publish`
+- if step 1 of execution fails, after addressing the error, you run the action
+  again
+- if step 2 of execution fails, after addressing the error, you run the action
+  again
+- if step 3 of execution fails (the Cargo.toml version was incremented), after
+  addressing the error, you should manually tag (github's ux or the cli) and
+  manually publish the crate with `cargo publish`
+- if step 4 of execution fails (the Cargo.toml version was incremented and
+  there's a new corresponding tag), after addressing the error, you should
+  manually publish the crate with `cargo publish`

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,25 +1,34 @@
 # Benchmarking
 
-Benchmarking numbers will vary across tests, specific grammars, rust versions, and hardware. With so many sources of noise, it is important to remember that "faster" is not always easy to define.
+Benchmarking numbers will vary across tests, specific grammars, rust versions,
+and hardware. With so many sources of noise, it is important to remember that
+"faster" is not always easy to define.
 
 With that in mind, BNF's benchmarking has the following goals:
 
 * identify statistically significant performance regressions
 * validate performance hypothesis
 
-These benchmarks are not run during continuous integration testing. But if a developer is attempting a full overhaul of the BNF parser, these benchmarks will help them identify large changes in performance.
+These benchmarks are not run during continuous integration testing. But if a
+developer is attempting a full overhaul of the BNF parser, these benchmarks will
+help them identify large changes in performance.
 
 ## Benchmarking Frameworks
 
-BNF uses two benchmarking frameworks to provide different perspectives on performance:
+BNF uses two benchmarking frameworks to provide different perspectives on
+performance:
 
 ### Criterion
 
-[Criterion][criterion] is used to run benchmarks with confidence. Criterion achieves this by running warmups, collecting a statistically significant sized sample, and generating informative reports.
+[Criterion][criterion] is used to run benchmarks with confidence. Criterion
+achieves this by running warmups, collecting a statistically significant sized
+sample, and generating informative reports.
 
 ### Divan
 
-[Divan][divan] provides additional insights into performance, particularly around memory allocation and throughput. It offers a different perspective on performance analysis compared to Criterion.
+[Divan][divan] provides additional insights into performance, particularly around
+memory allocation and throughput. It offers a different perspective on
+performance analysis compared to Criterion.
 
 ## How to Run
 
@@ -31,7 +40,9 @@ For Divan benchmarks:
 
 ## Cargo Criterion
 
-[cargo-criterion][cargo-criterion] is a plugin for Cargo which handles much of the heavy lifting for analyzing and reporting on Criterion-rs benchmarks. It eases generating performance report files.
+[cargo-criterion][cargo-criterion] is a plugin for Cargo which handles much of
+the heavy lifting for analyzing and reporting on Criterion-rs benchmarks. It
+eases generating performance report files.
 
 ### Install
 
@@ -51,11 +62,14 @@ For Divan:
 
 ## Tracing
 
-BNF has an optional "tracing" feature which will provide tracing spans during benchmarking.
+BNF has an optional "tracing" feature which will provide tracing spans during
+benchmarking.
 
-The benchmarks are enabled to write these tracing spans to `tracing.folded`. This data can then be parsed to provide a flamegraph:
+The benchmarks are enabled to write these tracing spans to `tracing.folded`.
+This data can then be parsed to provide a flamegraph:
 
-> RUST_LOG=DEBUG cargo criterion --features "tracing" && cat tracing.folded | inferno-flamegraph > flamegraph.svg
+> RUST_LOG=DEBUG cargo criterion --features "tracing" && cat tracing.folded |
+  inferno-flamegraph > flamegraph.svg
 
 [criterion]: https://crates.io/crates/criterion
 [cargo-criterion]: https://github.com/bheisler/cargo-criterion

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,8 @@ This example uses the DNA grammar from the main README:
 
 ### `parse_tree`
 
-A simple example showing how to use a `Grammar` to parse an input string and print the resulting parse tree.
+A simple example showing how to use a `Grammar` to parse an input string and
+print the resulting parse tree.
 
 **What it demonstrates:**
 
@@ -51,4 +52,4 @@ cargo run --example parse_tree
 **Expected output:**
 
 - The input string being parsed
-- The parse tree printed in a readable format, or a message if parsing fails 
+- The parse tree printed in a readable format, or a message if parsing fails


### PR DESCRIPTION
This PR fixes markdown formatting issues across all documentation files to comply with project standards and markdownlint rules.

## Changes Made

- Fixed line length violations (MD013) across multiple files
- Converted bare URLs to proper markdown links (MD034)
- Removed multiple blank lines and trailing spaces (MD012, MD009)
- Added proper header structure to pull request template (MD041)
- Fixed list formatting and indentation in issue templates (MD007, MD032)
- Ensured all files end with single newline (MD047)

## Verification

All files now pass markdownlint validation with zero violations.