### PR TITLE
Add explicit specification of start term in parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,25 @@ match parse_trees.next() {
     _ => println!("Grammar could not parse sentence"),
 }
 ```
+
+By default, `parse_input` implicitly starts from the first rule. To match another rule, 
+`parse_input_starting_with` can be used:
+
+```rust
+use bnf::{Grammar, Term};
+
+let input =
+    "<dna> ::= <base> | <base> <dna>
+    <base> ::= 'A' | 'C' | 'G' | 'T'";
+let grammar: Grammar = input.parse().unwrap();
+
+let sentence = "G";
+let target_production = Term::Nonterminal("base".to_string());
+
+let mut parse_trees = grammar.parse_input_starting_with(sentence, &target_production);
+match parse_trees.next() {
+    Some(parse_tree) => println!("{}", parse_tree),
+    _ => println!("Grammar could not parse sentence"),
+}
+```
+

--- a/examples/parse_tree_explicit_entrypoint.rs
+++ b/examples/parse_tree_explicit_entrypoint.rs
@@ -1,0 +1,44 @@
+//! Example: Parse a tree from input using a Grammar, specifing which production to start from
+//!
+//! This example demonstrates how to use a Grammar to parse an input string and print the resulting parse tree(s).
+//! In this example, the grammar is take from the the DNA grammar from the README, but reversed. By default, parser
+//! would assume that the input should be parsed with the first rule. This example demonstrates how
+//! to parse the input "GATTACA" with the second rule <dna> instead
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use bnf::Grammar;
+
+fn main() {
+    // Define a simple BNF grammar for DNA sequences
+    let bnf_input = r#"
+        <base> ::= 'A' | 'C' | 'G' | 'T'
+        <dna> ::= <base> | <base> <dna>
+    "#;
+
+    // Parse the BNF string into a Grammar object
+    let grammar: Grammar = match bnf_input.parse() {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("Failed to create grammar from BNF string: {e}");
+            return;
+        }
+    };
+
+    // Input string to parse
+    let sentence = "GATTACA";
+    println!("Parsing input with <dna>: {sentence}");
+
+    // Target to start from
+    let target_production = bnf::Term::Nonterminal("dna".to_string());
+
+    // Parse the input string using the grammar, trying to match the second <dna> target
+    let mut parse_trees = grammar.parse_input_starting_with(sentence, &target_production);
+    match parse_trees.next() {
+        Some(parse_tree) => {
+            println!("Parse tree:\n{parse_tree}");
+        }
+        None => {
+            println!("Grammar could not parse the sentence");
+        }
+    }
+}

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -15,6 +15,14 @@ pub fn parse<'gram>(
     ParseTreeIter::new(grammar, input)
 }
 
+pub fn parse_starting_with<'gram>(
+    grammar: &'gram crate::Grammar,
+    input: &'gram str,
+    starting_term: &'gram Term,
+) -> impl Iterator<Item = ParseTree<'gram>> {
+    ParseTreeIter::new_starting_with(grammar, input, starting_term)
+}
+
 /// A queue of [`TraversalId`] for processing, with repetitions ignored.
 #[derive(Debug, Default)]
 struct TraversalQueue {
@@ -187,6 +195,14 @@ impl<'gram> ParseTreeIter<'gram> {
             .starting_term()
             .expect("Grammar must have one production to parse");
 
+        Self::new_starting_with(grammar, input, starting_term)
+    }
+
+    pub fn new_starting_with(
+        grammar: &'gram crate::Grammar,
+        input: &'gram str,
+        starting_term: &'gram Term,
+    ) -> Self {
         let grammar = ParseGrammar::new(grammar);
 
         let input = InputRange::new(input);


### PR DESCRIPTION
## Description

This adds a new `parse_input_starting_with` to `Grammar` to allow to specify which rule to start with when parsing input. 

The regular `parse_input` implicitly assumed that the input should be parsed starting with the first rule, not allowing to define a single grammar with multiple possible targets to try. 

This should allow to handle cases as raised by issue #137, without any breaking change to current api. 

## Api

```rust
let sentence = "G";
let target_production = Term::Nonterminal("base".to_string());
let parse_trees = grammar.parse_input_starting_with(sentence, &target_production);
```

## Technical notes

As shown in tests, the starting term is not required to be reference equal to one of the production defined in the grammar. A simple equality of the term is enough. 

Let me know if there is anything I can improve, or if you think of any other test case. Thank you.