### PR TITLE
prefer hashbrown set and map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ all-features = true
 [lints.clippy]
 all = "deny"
 clone_on_ref_ptr = "deny"
+disallowed_methods = "deny"
+disallowed_types = "deny"
 complexity = "deny"
 dbg_macro = "deny"
 doc_markdown = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# Prefer crate::HashSet / crate::HashMap (hashbrown) over std
+disallowed-types = [
+    { path = "std::collections::HashSet", reason = "use crate::HashSet (hashbrown) for consistency and performance", replacement = "crate::HashSet" },
+    { path = "std::collections::HashMap", reason = "use crate::HashMap (hashbrown) for consistency and performance", replacement = "crate::HashMap" },
+]
+
+disallowed-methods = [
+    { path = "std::collections::HashSet::new", reason = "use crate::HashSet (hashbrown)", replacement = "crate::HashSet::new" },
+    { path = "std::collections::HashMap::new", reason = "use crate::HashMap (hashbrown)", replacement = "crate::HashMap::new" },
+]

--- a/src/earley/mod.rs
+++ b/src/earley/mod.rs
@@ -4,7 +4,9 @@ mod traversal;
 use crate::parser::grammar::ParseGrammar;
 use crate::{GrammarParser, ParseTree, ParseTreeNode, Term, tracing};
 use input_range::InputRange;
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
+
+use crate::HashSet;
 use std::rc::Rc;
 use traversal::{TermMatch, Traversal, TraversalId, TraversalTree};
 


### PR DESCRIPTION
noticed that one place in the project was still using the `std` `HashSet` instead of the crate / `hashbrown` one. 

this once change improved nearly all parsing benchmarks by +8% 😅 

so I thought it would be worth adding a clippy lint to catch this accidental misuse in the future!
